### PR TITLE
Dalvik and Python architectures

### DIFF
--- a/lib/metasploit/model/architecture.rb
+++ b/lib/metasploit/model/architecture.rb
@@ -22,6 +22,7 @@ module Metasploit
           'php',
           'ppc',
           'ppc64',
+          'python',
           'ruby',
           'sparc',
           'tty',
@@ -133,6 +134,13 @@ module Metasploit
               :endianness => 'big',
               :family => 'ppc',
               :summary => '64-bit Performance Optimization With Enhanced RISC - Performance Computing'
+          },
+          {
+              :abbreviation => 'python',
+              :bits => nil,
+              :endianness => nil,
+              :family => nil,
+              :summary => 'Python'
           },
           {
               :abbreviation => 'ruby',

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.5.1'
+    VERSION = '0.5.2'
   end
 end

--- a/spec/support/shared/examples/metasploit/model/architecture.rb
+++ b/spec/support/shared/examples/metasploit/model/architecture.rb
@@ -49,6 +49,10 @@ shared_examples_for 'Metasploit::Model::Architecture' do
         abbreviations.should include('ppc64')
       end
 
+      it 'should include python for Python code' do
+        abbreviations.should include('python')
+      end
+
       it 'should include ruby for Ruby code' do
         abbreviations.should include('ruby')
       end
@@ -154,6 +158,13 @@ shared_examples_for 'Metasploit::Model::Architecture' do
                           :summary => '64-bit Performance Optimization With Enhanced RISC - Performance Computing'
 
     it_should_behave_like 'Metasploit::Model::Architecture seed',
+                          :abbreviation => 'python',
+                          :bits => nil,
+                          :endianness => nil,
+                          :family => nil,
+                          :summary => 'Python'
+
+    it_should_behave_like 'Metasploit::Model::Architecture seed',
                           :abbreviation => 'ruby',
                           :bits => nil,
                           :endianness => nil,
@@ -212,6 +223,7 @@ shared_examples_for 'Metasploit::Model::Architecture' do
             'php',
             'ppc',
             'ppc64',
+            'python',
             'ruby',
             'sparc',
             'tty',


### PR DESCRIPTION
Add Dalvik architecture because it's already on metasploit-framework/master and Python architecture because it will once the [Python Meterpreter](https://github.com/rapid7/metasploit-framework/pull/2244) lands.
