### PR TITLE
Filter invalid children from union operations.

### DIFF
--- a/app/models/metasploit/model/search/operator/union.rb
+++ b/app/models/metasploit/model/search/operator/union.rb
@@ -15,12 +15,17 @@ class Metasploit::Model::Search::Operator::Union < Metasploit::Model::Search::Op
   # Unions children operating on `formatted_value`.
   #
   # @param formatted_value [String] value parsed from formatted operation.
-  # @return [Metasploit::Model::Search::Operation::Union]
+  # @return [Metasploit::Model::Search::Operation::Union] Union will not contain {#children} that are invalid.
   def operate_on(formatted_value)
     children = self.children(formatted_value)
 
+    # filter children for validity as valid values for one child won't necessarily be valid values for another child.
+    # this is specifically a problem with Metasploit::Model::Search::Operation::Set as no partial matching is allowed,
+    # but can also be a problem with string vs integer operations.
+    valid_children = children.select(&:valid?)
+
     Metasploit::Model::Search::Operation::Union.new(
-        :children => children,
+        :children => valid_children,
         :operator => self,
         :value => formatted_value
     )

--- a/lib/metasploit/model/configuration/autoload.rb
+++ b/lib/metasploit/model/configuration/autoload.rb
@@ -30,6 +30,11 @@ class Metasploit::Model::Configuration::Autoload < Metasploit::Model::Configurat
     @all_paths ||= (once_paths + paths).uniq
   end
 
+  # Eager loads all rb files under {#all_paths}.  Paths in {#all_paths} are sorted before loading, so that `app` will
+  # load before `lib`.  Files are required using `ActiveSupport::Dependencies::Loadable#require_dependency` so they
+  # interact with `ActiveSupport::Dependencies` loading correctly.
+  #
+  # @return [void]
   def eager_load!
     # sort to favor app over lib since it is assumed that app/models will define classes and lib will define modules
     # included in those classes that are defined under the class namespaces, so the class needs to be required first

--- a/lib/metasploit/model/configuration/autoload.rb
+++ b/lib/metasploit/model/configuration/autoload.rb
@@ -30,6 +30,18 @@ class Metasploit::Model::Configuration::Autoload < Metasploit::Model::Configurat
     @all_paths ||= (once_paths + paths).uniq
   end
 
+  def eager_load!
+    # sort to favor app over lib since it is assumed that app/models will define classes and lib will define modules
+    # included in those classes that are defined under the class namespaces, so the class needs to be required first
+    all_paths.sort.each do |load_path|
+      matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
+
+      Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
+        require_dependency file.sub(matcher, '\1')
+      end
+    end
+  end
+
   # {#relative_once_paths} converted to absolute paths.
   #
   # @return [Array<String>]

--- a/lib/metasploit/model/engine.rb
+++ b/lib/metasploit/model/engine.rb
@@ -1,26 +1,32 @@
-require 'rails'
+begin
+  require 'rails'
+# Metasploit::Model.configuration.autoload.eager_load! will load this file, but if rails is not available, it should not
+# break the caller of eager_load! (i.e. metasploit-framework)
+rescue LoadError => error
+  warn "rails could not be loaded, so Metasploit::Model::Engine will not be defined: #{error}"
+else
+  module Metasploit
+    module Model
+      # Rails engine for Metasploit::Model.  Will automatically be used if `Rails` is defined when
+      # 'metasploit/model' is required, as should be the case in any normal Rails application Gemfile where
+      # gem 'rails' is the first gem in the Gemfile.
+      class Engine < Rails::Engine
+        # @see http://viget.com/extend/rails-engine-testing-with-rspec-capybara-and-factorygirl
+        config.generators do |g|
+          g.assets false
+          g.fixture_replacement :factory_girl, :dir => 'spec/factories'
+          g.helper false
+          g.test_framework :rspec, :fixture => false
+        end
 
-module Metasploit
-  module Model
-    # Rails engine for Metasploit::Model.  Will automatically be used if `Rails` is defined when
-    # 'metasploit/model' is required, as should be the case in any normal Rails application Gemfile where
-    # gem 'rails' is the first gem in the Gemfile.
-    class Engine < Rails::Engine
-      # @see http://viget.com/extend/rails-engine-testing-with-rspec-capybara-and-factorygirl
-      config.generators do |g|
-        g.assets false
-        g.fixture_replacement :factory_girl, :dir => 'spec/factories'
-        g.helper false
-        g.test_framework :rspec, :fixture => false
-      end
+        initializer 'metasploit-model.prepend_factory_path', :after => 'factory_girl.set_factory_paths' do
+          if defined? FactoryGirl
+            relative_definition_file_path = config.generators.options[:factory_girl][:dir]
+            definition_file_path = root.join(relative_definition_file_path)
 
-      initializer 'metasploit-model.prepend_factory_path', :after => 'factory_girl.set_factory_paths' do
-        if defined? FactoryGirl
-          relative_definition_file_path = config.generators.options[:factory_girl][:dir]
-          definition_file_path = root.join(relative_definition_file_path)
-
-          # unshift so that dependent gems can modify metasploit-model's factories
-          FactoryGirl.definition_file_paths.unshift definition_file_path
+            # unshift so that dependent gems can modify metasploit-model's factories
+            FactoryGirl.definition_file_paths.unshift definition_file_path
+          end
         end
       end
     end

--- a/lib/metasploit/model/spec.rb
+++ b/lib/metasploit/model/spec.rb
@@ -1,3 +1,5 @@
+require 'rspec/core/shared_example_group'
+
 module Metasploit
   module Model
     # Helper methods for running specs for metasploit-model.

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.19.3'
+    VERSION = '0.19.4'
   end
 end

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.19.4'
+    VERSION = '0.19.5'
   end
 end

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.19.5'
+    VERSION = '0.19.6'
   end
 end

--- a/spec/app/models/metasploit/model/search/operator/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/union_spec.rb
@@ -26,11 +26,28 @@ describe Metasploit::Model::Search::Operator::Union do
       operator.operate_on(formatted_value)
     end
 
+    #
+    # lets
+    #
+
     let(:children) do
       [
-          double('Child')
+          invalid_child,
+          valid_child
       ]
     end
+
+    let(:valid_child) do
+      double('Valid Child', valid?: true)
+    end
+
+    let(:invalid_child) do
+      double('Invalid Child', valid?: false)
+    end
+
+    #
+    # Callbacks
+    #
 
     before(:each) do
       operator.stub(:children => children)
@@ -43,8 +60,12 @@ describe Metasploit::Model::Search::Operator::Union do
         operation.children
       end
 
-      it 'should be #children' do
-        operation_children.should == children
+      it 'rejected invalid children' do
+        expect(operation_children).not_to include(invalid_child)
+      end
+
+      it 'includes valid children' do
+        expect(operation_children).to include(valid_child)
       end
     end
 


### PR DESCRIPTION
MSP-9108
MSP-9277

Supersedes https://github.com/rapid7/metasploit-model/pull/8

Filter invalid children before adding them to
Metasploit::Model::Search::Operation:Union#children so that invalid
children won't stop the union from validating, which can cause
deprecated operators to fail.
