### PR TITLE
Fix payload reference name

### DIFF
--- a/app/models/metasploit/model/search/operator/union.rb
+++ b/app/models/metasploit/model/search/operator/union.rb
@@ -15,12 +15,17 @@ class Metasploit::Model::Search::Operator::Union < Metasploit::Model::Search::Op
   # Unions children operating on `formatted_value`.
   #
   # @param formatted_value [String] value parsed from formatted operation.
-  # @return [Metasploit::Model::Search::Operation::Union]
+  # @return [Metasploit::Model::Search::Operation::Union] Union will not contain {#children} that are invalid.
   def operate_on(formatted_value)
     children = self.children(formatted_value)
 
+    # filter children for validity as valid values for one child won't necessarily be valid values for another child.
+    # this is specifically a problem with Metasploit::Model::Search::Operation::Set as no partial matching is allowed,
+    # but can also be a problem with string vs integer operations.
+    valid_children = children.select(&:valid?)
+
     Metasploit::Model::Search::Operation::Union.new(
-        :children => children,
+        :children => valid_children,
         :operator => self,
         :value => formatted_value
     )

--- a/lib/metasploit/model/configuration/autoload.rb
+++ b/lib/metasploit/model/configuration/autoload.rb
@@ -30,6 +30,11 @@ class Metasploit::Model::Configuration::Autoload < Metasploit::Model::Configurat
     @all_paths ||= (once_paths + paths).uniq
   end
 
+  # Eager loads all rb files under {#all_paths}.  Paths in {#all_paths} are sorted before loading, so that `app` will
+  # load before `lib`.  Files are required using `ActiveSupport::Dependencies::Loadable#require_dependency` so they
+  # interact with `ActiveSupport::Dependencies` loading correctly.
+  #
+  # @return [void]
   def eager_load!
     # sort to favor app over lib since it is assumed that app/models will define classes and lib will define modules
     # included in those classes that are defined under the class namespaces, so the class needs to be required first

--- a/lib/metasploit/model/configuration/autoload.rb
+++ b/lib/metasploit/model/configuration/autoload.rb
@@ -30,6 +30,18 @@ class Metasploit::Model::Configuration::Autoload < Metasploit::Model::Configurat
     @all_paths ||= (once_paths + paths).uniq
   end
 
+  def eager_load!
+    # sort to favor app over lib since it is assumed that app/models will define classes and lib will define modules
+    # included in those classes that are defined under the class namespaces, so the class needs to be required first
+    all_paths.sort.each do |load_path|
+      matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
+
+      Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
+        require_dependency file.sub(matcher, '\1')
+      end
+    end
+  end
+
   # {#relative_once_paths} converted to absolute paths.
   #
   # @return [Array<String>]

--- a/lib/metasploit/model/engine.rb
+++ b/lib/metasploit/model/engine.rb
@@ -1,26 +1,32 @@
-require 'rails'
+begin
+  require 'rails'
+# Metasploit::Model.configuration.autoload.eager_load! will load this file, but if rails is not available, it should not
+# break the caller of eager_load! (i.e. metasploit-framework)
+rescue LoadError => error
+  warn "rails could not be loaded, so Metasploit::Model::Engine will not be defined: #{error}"
+else
+  module Metasploit
+    module Model
+      # Rails engine for Metasploit::Model.  Will automatically be used if `Rails` is defined when
+      # 'metasploit/model' is required, as should be the case in any normal Rails application Gemfile where
+      # gem 'rails' is the first gem in the Gemfile.
+      class Engine < Rails::Engine
+        # @see http://viget.com/extend/rails-engine-testing-with-rspec-capybara-and-factorygirl
+        config.generators do |g|
+          g.assets false
+          g.fixture_replacement :factory_girl, :dir => 'spec/factories'
+          g.helper false
+          g.test_framework :rspec, :fixture => false
+        end
 
-module Metasploit
-  module Model
-    # Rails engine for Metasploit::Model.  Will automatically be used if `Rails` is defined when
-    # 'metasploit/model' is required, as should be the case in any normal Rails application Gemfile where
-    # gem 'rails' is the first gem in the Gemfile.
-    class Engine < Rails::Engine
-      # @see http://viget.com/extend/rails-engine-testing-with-rspec-capybara-and-factorygirl
-      config.generators do |g|
-        g.assets false
-        g.fixture_replacement :factory_girl, :dir => 'spec/factories'
-        g.helper false
-        g.test_framework :rspec, :fixture => false
-      end
+        initializer 'metasploit-model.prepend_factory_path', :after => 'factory_girl.set_factory_paths' do
+          if defined? FactoryGirl
+            relative_definition_file_path = config.generators.options[:factory_girl][:dir]
+            definition_file_path = root.join(relative_definition_file_path)
 
-      initializer 'metasploit-model.prepend_factory_path', :after => 'factory_girl.set_factory_paths' do
-        if defined? FactoryGirl
-          relative_definition_file_path = config.generators.options[:factory_girl][:dir]
-          definition_file_path = root.join(relative_definition_file_path)
-
-          # unshift so that dependent gems can modify metasploit-model's factories
-          FactoryGirl.definition_file_paths.unshift definition_file_path
+            # unshift so that dependent gems can modify metasploit-model's factories
+            FactoryGirl.definition_file_paths.unshift definition_file_path
+          end
         end
       end
     end

--- a/lib/metasploit/model/module/ancestor.rb
+++ b/lib/metasploit/model/module/ancestor.rb
@@ -387,6 +387,31 @@ module Metasploit
           end
         end
 
+        # The name used to forming the {Metasploit::Model::Module::Class#reference_name} for payloads.
+        #
+        # @return [String] The {#reference_name} without the {#payload_type_directory} if {#payload_type} is `'single'`
+        #   or `'stage'`
+        # @return [String] The {#handler_type} if {#payload_type} is `'stager'`
+        # @return [nil] if {#module_type} is not `'payload'`
+        def payload_name
+          payload_name = nil
+
+          if module_type == Metasploit::Model::Module::Type::PAYLOAD
+            case payload_type
+              when 'single', 'stage'
+                if reference_name && payload_type_directory
+                  escaped_payload_type_directory = Regexp.escape(payload_type_directory)
+                  payload_type_directory_regexp = /^#{escaped_payload_type_directory}\//
+                  payload_name = reference_name.gsub(payload_type_directory_regexp, '')
+                end
+              when 'stager'
+                payload_name = handler_type
+            end
+          end
+
+          payload_name
+        end
+
         # The directory for {#payload_type} under {#module_type_directory} in {#real_path}.
         #
         # @return [String] first directory in reference_name
@@ -397,7 +422,7 @@ module Metasploit
 
           if payload? and reference_name
             head, _tail = reference_name.split(REFERENCE_NAME_SEPARATOR, 2)
-            directory = head.singularize
+            directory = head
           end
 
           directory

--- a/lib/metasploit/model/module/class.rb
+++ b/lib/metasploit/model/module/class.rb
@@ -323,19 +323,17 @@ module Metasploit
         #
         # Derives {#reference_name} for single payload.
         #
-        # @return [String] '<single_ancestor.reference_name>/<single_ancestor.handler_type>'
+        # @return [String, nil] '<ancestor.payload_name>'
         # @return [nil] unless exactly one {#ancestors ancestor}.
-        # @return [nil] unless {Metasploit::Model::Module::Ancestor#payload_type} is 'single'.
-        # @return [nil] if {Metasploit::Model::Module::Ancestor#reference_name} is `nil`.
-        # @return [nil] if {Metasploit::Model::Module::Ancestor#handler_type} is `nil`.
+        # @return [nil] unless ancestor's {Metasploit::Model::Module::Ancestor#payload_type} is `'single'`.
         def derived_single_payload_reference_name
           derived = nil
 
           if ancestors.length == 1
             ancestor = ancestors.first
 
-            if ancestor.payload_type == 'single' and ancestor.reference_name and ancestor.handler_type
-              derived = "#{ancestor.reference_name}/#{ancestor.handler_type}"
+            if ancestor.payload_type == 'single'
+              derived = ancestor.payload_name
             end
           end
 
@@ -347,11 +345,11 @@ module Metasploit
         #
         # Derives {#reference_name} for staged payload.
         #
-        # @return [String] '<stage_ancestor.reference_name>/<stager_ancestor.handler_type>'
+        # @return [String] '<stage_ancestor.payload_name>/<stager_ancestor.payload_name>'
         # @return [nil] unless exactly two {#ancestors ancestor}.
         # @return [nil] unless {Metasploit::Model::Module::Ancestor#payload_type} is 'single'.
-        # @return [nil] if {Metasploit::Model::Module::Ancestor#reference_name} is `nil`.
-        # @return [nil] if {Metasploit::Model::Module::Ancestor#handler_type} is `nil`.
+        # @return [nil] if {Metasploit::Model::Module::Ancestor#payload_name} is `nil` for the stage.
+        # @return [nil] if {Metasploit::Model::Module::Ancestor#payload_name} is `nil` for the stager.
         def derived_staged_payload_reference_name
           derived = nil
 
@@ -363,15 +361,15 @@ module Metasploit
             if stage_ancestors.length == 1
               stage_ancestor = stage_ancestors.first
 
-              if stage_ancestor.reference_name
+              if stage_ancestor.payload_name
                 stager_ancestors = ancestors_by_payload_type.fetch('stager', [])
 
                 # length can be 0..1
                 if stager_ancestors.length == 1
                   stager_ancestor = stager_ancestors.first
 
-                  if stager_ancestor.handler_type
-                    derived = "#{stage_ancestor.reference_name}/#{stager_ancestor.handler_type}"
+                  if stager_ancestor.payload_name
+                    derived = "#{stage_ancestor.payload_name}/#{stager_ancestor.payload_name}"
                   end
                 end
               end

--- a/lib/metasploit/model/spec.rb
+++ b/lib/metasploit/model/spec.rb
@@ -1,3 +1,5 @@
+require 'rspec/core/shared_example_group'
+
 module Metasploit
   module Model
     # Helper methods for running specs for metasploit-model.

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.19.3'
+    VERSION = '0.19.4'
   end
 end

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.19.4'
+    VERSION = '0.19.5'
   end
 end

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.19.5'
+    VERSION = '0.19.6'
   end
 end

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -4,6 +4,6 @@ module Metasploit
     # considered unstable because certain code may not be shared between metasploit_data_models, metasploit-framework,
     # and pro, so support code for that may be removed in the future.  Because of the unstable API the version should
     # remain below 1.0.0
-    VERSION = '0.19.6'
+    VERSION = '0.20.0'
   end
 end

--- a/spec/app/models/metasploit/model/search/operator/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/union_spec.rb
@@ -26,11 +26,28 @@ describe Metasploit::Model::Search::Operator::Union do
       operator.operate_on(formatted_value)
     end
 
+    #
+    # lets
+    #
+
     let(:children) do
       [
-          double('Child')
+          invalid_child,
+          valid_child
       ]
     end
+
+    let(:valid_child) do
+      double('Valid Child', valid?: true)
+    end
+
+    let(:invalid_child) do
+      double('Invalid Child', valid?: false)
+    end
+
+    #
+    # Callbacks
+    #
 
     before(:each) do
       operator.stub(:children => children)
@@ -43,8 +60,12 @@ describe Metasploit::Model::Search::Operator::Union do
         operation.children
       end
 
-      it 'should be #children' do
-        operation_children.should == children
+      it 'rejected invalid children' do
+        expect(operation_children).not_to include(invalid_child)
+      end
+
+      it 'includes valid children' do
+        expect(operation_children).to include(valid_child)
       end
     end
 

--- a/spec/support/shared/examples/metasploit/model/module/ancestor.rb
+++ b/spec/support/shared/examples/metasploit/model/module/ancestor.rb
@@ -1616,6 +1616,216 @@ Metasploit::Model::Spec.shared_examples_for 'Module::Ancestor' do
     end
   end
 
+  context '#payload_name' do
+    subject(:payload_name) do
+      module_ancestor.payload_name
+    end
+
+    let(:module_ancestor) do
+      FactoryGirl.build(
+          module_ancestor_factory,
+          handler_type: handler_type,
+          module_type: module_type,
+          payload_type: payload_type
+      )
+    end
+
+    context '#module_type' do
+      context 'with payload' do
+        #
+        # Shared examples
+        #
+
+        shared_examples_for 'prefix payload_name' do
+          let(:handler_type) do
+            nil
+          end
+
+          context 'with #reference_name' do
+            #
+            # lets
+            #
+
+            let(:expected_payload_name) do
+              'expected/payload/name'
+            end
+
+            let(:reference_name) do
+              "#{payload_type_directory}/#{expected_payload_name}"
+            end
+
+            #
+            # Callbacks
+            #
+
+            before(:each) do
+              module_ancestor.reference_name = reference_name
+            end
+
+            it "strips #payload_type_directory and '/' from #reference_name" do
+              expect(payload_name).to eq(expected_payload_name)
+            end
+          end
+
+          context 'without #reference_name' do
+            before(:each) do
+              module_ancestor.reference_name = nil
+            end
+
+            it { should be_nil }
+          end
+        end
+
+        #
+        # lets
+        #
+
+        let(:module_type) do
+          'payload'
+        end
+
+        context '#payload_type' do
+          context 'with single' do
+            let(:payload_type) do
+              'single'
+            end
+
+            it_should_behave_like 'prefix payload_name' do
+              let(:payload_type_directory) do
+                'singles'
+              end
+            end
+          end
+
+          context 'with stage' do
+            let(:payload_type) do
+              'stage'
+            end
+
+            it_should_behave_like 'prefix payload_name' do
+              let(:payload_type_directory) do
+                'stages'
+              end
+            end
+          end
+
+          context 'with stager' do
+            let(:payload_type) do
+              'stager'
+            end
+
+            context 'with #handler_type' do
+              let(:handler_type) do
+                FactoryGirl.generate :metasploit_model_module_handler_type
+              end
+
+              it 'uses #handler_type' do
+                expect(payload_name).to eq(handler_type)
+              end
+            end
+
+            context 'without #handler_type' do
+              let(:handler_type) do
+                nil
+              end
+
+              it { should be_nil }
+            end
+          end
+
+          context 'with other' do
+            let(:handler_type) do
+              nil
+            end
+
+            let(:payload_type) do
+              'unknown_payload_type'
+            end
+
+            it { should be_nil }
+          end
+        end
+      end
+
+      context 'without payload' do
+        let(:handler_type) do
+          nil
+        end
+
+        let(:module_type) do
+          FactoryGirl.generate :metasploit_model_non_payload_module_type
+        end
+
+        let(:payload_type) do
+          nil
+        end
+
+        it { should be_nil }
+      end
+    end
+  end
+
+  context '#payload_type_directory' do
+    subject(:payload_type_directory) do
+      module_ancestor.payload_type_directory
+    end
+
+    let(:module_ancestor) do
+      FactoryGirl.build(
+          module_ancestor_factory,
+          module_type: module_type
+      )
+    end
+
+    context 'with payload' do
+      let(:module_type) do
+        'payload'
+      end
+
+      before(:each) do
+        module_ancestor.reference_name = reference_name
+      end
+
+      context 'with #reference_name' do
+        let(:expected_payload_type_directory) do
+          payload_type_directories.sample
+        end
+
+        let(:payload_type_directories) do
+          [
+              'singles',
+              'stages',
+              'stagers'
+          ]
+        end
+
+        let(:reference_name) do
+          "#{expected_payload_type_directory}/reference/name/tail"
+        end
+
+        it 'is name before REFERENCE_NAME_SEPARATOR' do
+          expect(payload_type_directory).to eq(expected_payload_type_directory)
+        end
+      end
+
+      context 'without #reference_name' do
+        let(:reference_name) do
+          nil
+        end
+
+        it { should be_nil }
+      end
+    end
+
+    context 'without payload' do
+      let(:module_type) do
+        FactoryGirl.generate :metasploit_model_non_payload_module_type
+      end
+
+      it { should be_nil }
+    end
+  end
+
   context '#relative_file_names' do
     subject(:relative_file_names) do
       module_ancestor.relative_file_names

--- a/spec/support/shared/examples/metasploit/model/module/class.rb
+++ b/spec/support/shared/examples/metasploit/model/module/class.rb
@@ -1241,30 +1241,20 @@ Metasploit::Model::Spec.shared_examples_for 'Module::Class' do
         end
 
         context 'with reference_name' do
+          let(:payload_name) do
+            'payload/name'
+          end
+
+          let(:payload_type_directory) do
+            'singles'
+          end
+
           let(:reference_name) do
-            "payload/singles/reference/name"
+            "#{payload_type_directory}/#{payload_name}"
           end
 
-          before(:each) do
-            ancestor.handler_type = handler_type
-          end
-
-          context 'with handler_type' do
-            let(:handler_type) do
-              FactoryGirl.generate :metasploit_model_module_handler_type
-            end
-
-            it 'should return <reference_name>/<handler_type>' do
-              derived_single_payload_reference_name.should == "#{reference_name}/#{handler_type}"
-            end
-          end
-
-          context 'without handler_type' do
-            let(:handler_type) do
-              nil
-            end
-
-            it { should be_nil }
+          it 'should return Metasploit::Model::Module::Ancestor#payload_name' do
+            expect(derived_single_payload_reference_name).to eq(payload_name)
           end
         end
 
@@ -1314,8 +1304,16 @@ Metasploit::Model::Spec.shared_examples_for 'Module::Class' do
         end
 
         context 'with reference_name' do
+          let(:stage_payload_name) do
+            'payload/name'
+          end
+
           let(:stage_reference_name) do
-            "payload/stages/reference/name"
+            "#{stage_type_directory}/#{stage_payload_name}"
+          end
+
+          let(:stage_type_directory) do
+            'stages'
           end
 
           context 'with 1 stager' do
@@ -1339,8 +1337,8 @@ Metasploit::Model::Spec.shared_examples_for 'Module::Class' do
                 FactoryGirl.generate :metasploit_model_module_handler_type
               end
 
-              it 'should be <stage.reference_name>/<stager.handler_type>' do
-                derived_staged_payload_reference_name.should == "#{stage_reference_name}/#{stager_handler_type}"
+              it 'should be <stage.payload_name>/<stager.handler_type>' do
+                expect(derived_staged_payload_reference_name).to eq("#{stage_payload_name}/#{stager_handler_type}")
               end
             end
 


### PR DESCRIPTION
MSP-2878
MSP-9108
MSP-9277

Supersedes https://github.com/rapid7/metasploit-model/pull/9 which superseded https://github.com/rapid7/metasploit-model/pull/8.

For single payload classes, strip the payload type directory, 'singles' from the ancestor reference name to get the class reference name.  For staged payload classes, strip the payload type directory, 'stages' from the stage ancestor reference name and append the handler_type from the stager.
