### PR TITLE
allow a Wildcard Realm Type

### DIFF
--- a/lib/metasploit/model/realm/key.rb
+++ b/lib/metasploit/model/realm/key.rb
@@ -29,20 +29,25 @@ module Metasploit::Model::Realm::Key
   # database and does not allow authenticating to just a server (which would be an `Mdm::Service`).
   POSTGRESQL_DATABASE = 'PostgreSQL Database'
 
+  # This is a Wildcard Realm Type which indicates we don't know or care what type of Realm it is.
+  WILDCARD = '*'
+
   # All values that are valid for {Metasploit::Credential::Realm#key}.
   ALL = [
-      ACTIVE_DIRECTORY_DOMAIN,
-      DB2_DATABASE,
-      ORACLE_SYSTEM_IDENTIFIER,
-      POSTGRESQL_DATABASE
+    ACTIVE_DIRECTORY_DOMAIN,
+    DB2_DATABASE,
+    ORACLE_SYSTEM_IDENTIFIER,
+    POSTGRESQL_DATABASE,
+    WILDCARD
   ]
 
   # A map of short names, suitable for use on the command line, to the
   # full human-readable constants above.
   SHORT_NAMES = {
-    'domain' => ACTIVE_DIRECTORY_DOMAIN,
-    'db2db'  => DB2_DATABASE,
-    'sid'    => ORACLE_SYSTEM_IDENTIFIER,
-    'pgdb'   => POSTGRESQL_DATABASE,
+    'domain'   => ACTIVE_DIRECTORY_DOMAIN,
+    'db2db'    => DB2_DATABASE,
+    'sid'      => ORACLE_SYSTEM_IDENTIFIER,
+    'pgdb'     => POSTGRESQL_DATABASE,
+    'wildcard' => WILDCARD
   }
 end

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 27
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 1
+      PATCH = 2
+
+      PRERELEASE = 'wildcard-realm-type'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/lib/metasploit/model/realm/key_spec.rb
+++ b/spec/lib/metasploit/model/realm/key_spec.rb
@@ -19,6 +19,7 @@ describe Metasploit::Model::Realm::Key do
       it { should include described_class::ACTIVE_DIRECTORY_DOMAIN }
       it { should include described_class::ORACLE_SYSTEM_IDENTIFIER }
       it { should include described_class::POSTGRESQL_DATABASE }
+      it { should include described_class::WILDCARD }
     end
 
     context 'ORACLE_SYSTEM_IDENTIFIER' do
@@ -36,6 +37,15 @@ describe Metasploit::Model::Realm::Key do
       end
 
       it { should == 'PostgreSQL Database' }
+      it { should be_in described_class::ALL }
+    end
+
+    context 'WILDCARD' do
+      subject(:wildcard) do
+        described_class::WILDCARD
+      end
+
+      it { should == '*' }
       it { should be_in described_class::ALL }
     end
 


### PR DESCRIPTION
Not much here. Just adds a Wildcard Realm type for when we don't know or acre what type of Realm it is.
# Verification Steps
- [x] `bundle install`
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.
## Version
- [x] Edit `lib/metasploit/model/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.
## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.
## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures
## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`
# Release
## JRuby
- [x] `rvm use jruby@metasploit-model`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake release`
## MRI Ruby
- [x] `rvm use ruby-1.9.3@metasploit-model`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake release`
