### PR TITLE
Add SAP Client Realm::Key constant

### DIFF
--- a/lib/metasploit/model/realm/key.rb
+++ b/lib/metasploit/model/realm/key.rb
@@ -27,6 +27,10 @@ module Metasploit::Model::Realm::Key
   # database and does not allow authenticating to just a server (which would be an `Mdm::Service`).
   POSTGRESQL_DATABASE = 'PostgreSQL Database'
 
+  # A SAP client number. Each SAP instance can run multiple clients which are
+  # identified by a three digit number, e.g. 000, 001, or 066.
+  SAP_CLIENT = 'SAP Client'
+
   # This is a Wildcard Realm Type which indicates we don't know or care what type of Realm it is.
   WILDCARD = '*'
 
@@ -36,6 +40,7 @@ module Metasploit::Model::Realm::Key
     DB2_DATABASE,
     ORACLE_SYSTEM_IDENTIFIER,
     POSTGRESQL_DATABASE,
+    SAP_CLIENT,
     WILDCARD
   ]
 
@@ -46,6 +51,7 @@ module Metasploit::Model::Realm::Key
     'db2db'    => DB2_DATABASE,
     'sid'      => ORACLE_SYSTEM_IDENTIFIER,
     'pgdb'     => POSTGRESQL_DATABASE,
+    'client'   => SAP_CLIENT,
     'wildcard' => WILDCARD
   }
 end

--- a/spec/lib/metasploit/model/realm/key_spec.rb
+++ b/spec/lib/metasploit/model/realm/key_spec.rb
@@ -19,6 +19,7 @@ describe Metasploit::Model::Realm::Key do
       it { should include described_class::ACTIVE_DIRECTORY_DOMAIN }
       it { should include described_class::ORACLE_SYSTEM_IDENTIFIER }
       it { should include described_class::POSTGRESQL_DATABASE }
+      it { should include described_class::SAP_CLIENT }
       it { should include described_class::WILDCARD }
     end
 
@@ -37,6 +38,15 @@ describe Metasploit::Model::Realm::Key do
       end
 
       it { should == 'PostgreSQL Database' }
+      it { should be_in described_class::ALL }
+    end
+
+    context 'SAP CLIENT' do
+      subject(:sap_client) do
+        described_class::SAP_CLIENT
+      end
+
+      it { should == 'SAP Client' }
       it { should be_in described_class::ALL }
     end
 


### PR DESCRIPTION
SAP instances have the notion of a client (which is actually more like a server instance..). 

E.g. a SAP instance may have clients 000, 001, 066. Each with its own users and passwords.

```
Client:User:Password
066:SAP*:PASSWD
```
