### PR TITLE
Feature/msp 11186/remove deprecation messages from dummy app

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -7,7 +7,7 @@ unless ENV['RM_INFO']
 end
 
 SimpleCov.configure do
-  load_adapter('rails')
+  load_profile('rails')
 
   # ignore this file
 	add_filter '.simplecov'

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -9,6 +9,7 @@ module Metasploit
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 0
 
+      PRERELEASE = 'remove-deprecation-messages-from-dummy-app'
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
       #

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -6,8 +6,8 @@ Dummy::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
+
+  config.eager_load = false
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -4,6 +4,8 @@ Dummy::Application.configure do
   # Code is not reloaded between requests
   config.cache_classes = true
 
+  config.eager_load = true
+
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -7,12 +7,12 @@ Dummy::Application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  config.eager_load = true
+
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true


### PR DESCRIPTION
### Description
  
This PR eliminates the following warnings for Rails 4

* Fix whiny_nils warning
* Fix load_adapter warning
* Fix config.eager_load warning

### Verification Steps

Rails 3

* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no spec failures

Rails 4

* [ ] switch to Rails 4 env
* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no load_adapter deprecation warnings
  
  `method load_adapter is deprecated. use load_profile instead`

* [ ] verify no whiny_nils deprecation warnings

  ```
  DEPRECATION WARNING: config.whiny_nils option is deprecated and no longer
  works. (called from block in <top (required)> at /Users/sgonzalez/Projects/rapid7-
  other/metasploit-model/spec/dummy/config/environments/test.rb:15)
  ```

* [ ] verify no config.eager_load warning

  ```
  config.eager_load is set to nil. Please update your config/environments/*.rb
  files accordingly:

    * development - set it to false
    * test - set it to false (unless you use a tool that preloads your test environment)
    * production - set it to true
  ```

### Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

### Version
* [ ] Edit `lib/metasploit-model/version.rb`
* [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

### Gem build
* [ ] gem build *.gemspec
* [ ] VERIFY the gem has no '.pre' version suffix.

### RSpec
* [ ] `rake spec`
* [ ] VERIFY version examples pass without failures

### Commit & Push
* [ ] `git commit -a`
* [ ] `git push origin master`

## Release
### JRuby
* [ ] `rvm use jruby@metasploit-model`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`

### MRI Ruby
* [ ] `rvm use ruby-2.1.5@metasploit-model`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`
