### PR TITLE
Upgrade to rspec 3.1+

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,2 @@
---backtrace
---colour
---drb
---format documentation
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,9 @@ group :test do
   gem 'coveralls', require: false
   # Engine tasks are loaded using railtie
   gem 'railties', *rails_version_constraint
-  gem 'rspec'
+  gem 'rspec', '~> 3.1'
   # need rspec-core >= 2.14.0 because 2.14.0 introduced RSpec::Core::SharedExampleGroup::TopLevel
-  gem 'rspec-core', '>= 2.14.0', '< 3.0.0'
+  gem 'rspec-core', '>= 2.14.0'
   # need rspec-rails >= 2.12.0 as 2.12.0 adds support for redefining named subject in nested context that uses the
   # named subject from the outer context without causing a stack overflow.
   gem 'rspec-rails', '>= 2.12.0'

--- a/Gemfile
+++ b/Gemfile
@@ -26,12 +26,7 @@ group :test do
   gem 'coveralls', require: false
   # Engine tasks are loaded using railtie
   gem 'railties', *rails_version_constraint
-  gem 'rspec', '~> 3.1'
-  # need rspec-core >= 2.14.0 because 2.14.0 introduced RSpec::Core::SharedExampleGroup::TopLevel
-  gem 'rspec-core', '>= 2.14.0'
-  # need rspec-rails >= 2.12.0 as 2.12.0 adds support for redefining named subject in nested context that uses the
-  # named subject from the outer context without causing a stack overflow.
-  gem 'rspec-rails', '>= 2.12.0'
+  gem 'rspec-rails', '~> 3.1'
   # In a full rails project, factory_girl_rails would be in both the :development, and :test group, but since we only
   # want rails in :test, factory_girl_rails must also only be in :test.
   # add matchers from shoulda, such as validates_presence_of, which are useful for testing validations

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 30
       # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'rspec-3-1'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/metasploit/model/association/reflection_spec.rb
+++ b/spec/app/models/metasploit/model/association/reflection_spec.rb
@@ -1,10 +1,8 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Association::Reflection, type: :model do
+RSpec.describe Metasploit::Model::Association::Reflection, type: :model do
   context 'validations' do
-    it { should validate_presence_of :model }
-    it { should validate_presence_of :name }
-    it { should validate_presence_of :class_name }
+    it { is_expected.to validate_presence_of :model }
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :class_name }
   end
 
   context '#klass' do
@@ -42,7 +40,7 @@ describe Metasploit::Model::Association::Reflection, type: :model do
     end
 
     it 'should return Class with Class#name #class_name' do
-      klass.should == class_name_class
+      expect(klass).to eq(class_name_class)
     end
   end
 end

--- a/spec/app/models/metasploit/model/association/reflection_spec.rb
+++ b/spec/app/models/metasploit/model/association/reflection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Association::Reflection do
+describe Metasploit::Model::Association::Reflection, type: :model do
   context 'validations' do
     it { should validate_presence_of :model }
     it { should validate_presence_of :name }

--- a/spec/app/models/metasploit/model/search/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/base_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Group::Base, type: :model do
+RSpec.describe Metasploit::Model::Search::Group::Base, type: :model do
   it { should ensure_length_of(:children).is_at_least(1) }
 end

--- a/spec/app/models/metasploit/model/search/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/base_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe Metasploit::Model::Search::Group::Base, type: :model do
-  it { should ensure_length_of(:children).is_at_least(1) }
+  it { is_expected.to ensure_length_of(:children).is_at_least(1) }
 end

--- a/spec/app/models/metasploit/model/search/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/base_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Group::Base do
+describe Metasploit::Model::Search::Group::Base, type: :model do
   it { should ensure_length_of(:children).is_at_least(1) }
 end

--- a/spec/app/models/metasploit/model/search/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/intersection_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Group::Intersection, type: :model do
+RSpec.describe Metasploit::Model::Search::Group::Intersection, type: :model do
   it { should be_a Metasploit::Model::Search::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/intersection_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe Metasploit::Model::Search::Group::Intersection, type: :model do
-  it { should be_a Metasploit::Model::Search::Group::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/intersection_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Group::Intersection do
+describe Metasploit::Model::Search::Group::Intersection, type: :model do
   it { should be_a Metasploit::Model::Search::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/union_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe Metasploit::Model::Search::Group::Union, type: :model do
-  it { should be_a Metasploit::Model::Search::Group::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/union_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Group::Union, type: :model do
+RSpec.describe Metasploit::Model::Search::Group::Union, type: :model do
   it { should be_a Metasploit::Model::Search::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/union_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Group::Union do
+describe Metasploit::Model::Search::Group::Union, type: :model do
   it { should be_a Metasploit::Model::Search::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/operation/association_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/association_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Association do
+describe Metasploit::Model::Search::Operation::Association, type: :model do
   subject(:operation) {
     described_class.new(
         source_operation: source_operation

--- a/spec/app/models/metasploit/model/search/operation/association_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/association_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Metasploit::Model::Search::Operation::Association, type: :model d
             true
           }
 
-          it { should_not include(invalid_error) }
+          it { is_expected.not_to include(invalid_error) }
         end
 
         context 'without valid' do
@@ -41,7 +41,7 @@ RSpec.describe Metasploit::Model::Search::Operation::Association, type: :model d
             false
           }
 
-          it { should include(invalid_error) }
+          it { is_expected.to include(invalid_error) }
         end
       end
 
@@ -54,12 +54,12 @@ RSpec.describe Metasploit::Model::Search::Operation::Association, type: :model d
           nil
         }
 
-        it { should include(blank_error) }
-        it { should_not include(invalid_error) }
+        it { is_expected.to include(blank_error) }
+        it { is_expected.not_to include(invalid_error) }
       end
     end
   end
 
-  it { should_not respond_to :value }
-  it { should_not respond_to :value= }
+  it { is_expected.not_to respond_to :value }
+  it { is_expected.not_to respond_to :value= }
 end

--- a/spec/app/models/metasploit/model/search/operation/association_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/association_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Association, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Association, type: :model do
   subject(:operation) {
     described_class.new(
         source_operation: source_operation

--- a/spec/app/models/metasploit/model/search/operation/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/base_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Base, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Base, type: :model do
   subject(:operation) do
     described_class.new
   end
@@ -40,7 +38,7 @@ describe Metasploit::Model::Search::Operation::Base, type: :model do
             end
 
             it 'should not record error on operator' do
-              errors.should_not include(error)
+              expect(errors).not_to include(error)
             end
           end
 
@@ -50,7 +48,7 @@ describe Metasploit::Model::Search::Operation::Base, type: :model do
             end
 
             it 'should record error on operator' do
-              errors.should include(error)
+              expect(errors).to include(error)
             end
           end
         end
@@ -61,7 +59,7 @@ describe Metasploit::Model::Search::Operation::Base, type: :model do
           end
 
           it 'should not record error on operator' do
-            errors.should_not include(error)
+            expect(errors).not_to include(error)
           end
         end
       end

--- a/spec/app/models/metasploit/model/search/operation/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/base_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Metasploit::Model::Search::Operation::Base, type: :model do
 
   context 'validations' do
     context 'operator' do
-      it { should validate_presence_of(:operator) }
+      it { is_expected.to validate_presence_of(:operator) }
 
       context 'valid' do
         let(:errors) do

--- a/spec/app/models/metasploit/model/search/operation/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/base_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Base do
+describe Metasploit::Model::Search::Operation::Base, type: :model do
   subject(:operation) do
     described_class.new
   end

--- a/spec/app/models/metasploit/model/search/operation/boolean_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/boolean_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Metasploit::Model::Search::Operation::Boolean, type: :model do
   end
 
   context 'validations' do
-    it { should allow_value(false).for(:value) }
-    it { should allow_value(true).for(:value) }
-    it { should_not allow_value(nil).for(:value) }
+    it { is_expected.to allow_value(false).for(:value) }
+    it { is_expected.to allow_value(true).for(:value) }
+    it { is_expected.not_to allow_value(nil).for(:value) }
   end
 
   context '#value' do

--- a/spec/app/models/metasploit/model/search/operation/boolean_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/boolean_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Boolean, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Boolean, type: :model do
   context 'CONSTANTS' do
     context 'FORMATTED_VALUE_TO_VALUE' do
       subject(:formatted_value_to_value) do
@@ -54,7 +52,7 @@ describe Metasploit::Model::Search::Operation::Boolean, type: :model do
       end
 
       it 'should return value unparsed' do
-        value.should == formatted_value
+        expect(value).to eq(formatted_value)
       end
     end
   end

--- a/spec/app/models/metasploit/model/search/operation/boolean_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/boolean_spec.rb
@@ -1,14 +1,19 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Boolean do
+describe Metasploit::Model::Search::Operation::Boolean, type: :model do
   context 'CONSTANTS' do
     context 'FORMATTED_VALUE_TO_VALUE' do
       subject(:formatted_value_to_value) do
         described_class::FORMATTED_VALUE_TO_VALUE
       end
 
-      its(['false']) { should be_false }
-      its(['true']) { should be_true }
+      it "maps 'false' to false" do
+        expect(formatted_value_to_value['false']).to eq(false)
+      end
+
+      it "maps 'true' to true" do
+        expect(formatted_value_to_value['true']).to eq(true)
+      end
     end
   end
 
@@ -32,7 +37,7 @@ describe Metasploit::Model::Search::Operation::Boolean do
         'false'
       end
 
-      it { should be_false }
+      it { is_expected.to eq(false) }
     end
 
     context "with 'true'" do
@@ -40,7 +45,7 @@ describe Metasploit::Model::Search::Operation::Boolean do
         'true'
       end
 
-      it { should be_true }
+      it { is_expected.to eq(true) }
     end
 
     context 'with other' do

--- a/spec/app/models/metasploit/model/search/operation/date_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/date_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Date do
+describe Metasploit::Model::Search::Operation::Date, type: :model do
   context 'validation' do
     context 'value' do
       before(:each) do

--- a/spec/app/models/metasploit/model/search/operation/date_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/date_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Date, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Date, type: :model do
   context 'validation' do
     context 'value' do
       before(:each) do
@@ -25,7 +23,7 @@ describe Metasploit::Model::Search::Operation::Date, type: :model do
         end
 
         it 'should not record error' do
-          errors.should_not include(error)
+          expect(errors).not_to include(error)
         end
       end
 
@@ -35,7 +33,7 @@ describe Metasploit::Model::Search::Operation::Date, type: :model do
         end
 
         it 'should record error' do
-          errors.should include(error)
+          expect(errors).to include(error)
         end
       end
     end
@@ -56,7 +54,7 @@ describe Metasploit::Model::Search::Operation::Date, type: :model do
       end
 
       it 'should be passed in Date' do
-        value.should == formatted_value
+        expect(value).to eq(formatted_value)
       end
     end
 
@@ -71,7 +69,7 @@ describe Metasploit::Model::Search::Operation::Date, type: :model do
         end
 
         it 'should be parsed Date' do
-          value.should == date
+          expect(value).to eq(date)
         end
       end
 
@@ -81,7 +79,7 @@ describe Metasploit::Model::Search::Operation::Date, type: :model do
         end
 
         it 'should pass through value' do
-          value.should be formatted_value
+          expect(value).to be formatted_value
         end
       end
     end

--- a/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Group::Base do
+describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
   subject(:group) do
     described_class.new
   end

--- a/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
   subject(:group) do
     described_class.new
   end
@@ -48,25 +46,25 @@ describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
           context 'with all valid' do
             before(:each) do
               children.each do |child|
-                child.stub(valid?: true)
+                allow(child).to receive(:valid?).and_return(true)
               end
             end
 
             it 'does not add error on :children' do
               group.valid?
 
-              group.errors[:children].should_not include(error)
+              expect(group.errors[:children]).not_to include(error)
             end
           end
 
           context 'with later valid' do
             before(:each) do
-              children.first.stub(valid?: false)
-              children.second.stub(valid?: true)
+              allow(children.first).to receive(:valid?).and_return(false)
+              allow(children.second).to receive(:valid?).and_return(true)
             end
 
             it 'does not short-circuit and validates all children' do
-              children.second.should_receive(:valid?).and_return(true)
+              expect(children.second).to receive(:valid?).and_return(true)
 
               children_valid
             end
@@ -74,7 +72,7 @@ describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
             it 'should add error on :children' do
               group.valid?
 
-              group.errors[:children].should include(error)
+              expect(group.errors[:children]).to include(error)
             end
           end
         end
@@ -87,7 +85,7 @@ describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
           it 'does not add error on :children' do
             group.valid?
 
-            group.errors[:children].should_not include(error)
+            expect(group.errors[:children]).not_to include(error)
           end
         end
       end
@@ -100,7 +98,7 @@ describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
     end
 
     context 'default' do
-      it { should == [] }
+      it { is_expected.to eq([]) }
     end
 
     context 'with attribute' do
@@ -117,7 +115,7 @@ describe Metasploit::Model::Search::Operation::Group::Base, type: :model do
       end
 
       it 'is the value passed with :children to #new' do
-        children.should == expected_children
+        expect(children).to eq(expected_children)
       end
     end
   end

--- a/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe Metasploit::Model::Search::Operation::Group::Base, type: :model d
     described_class.new
   end
 
-  it { should be_a Metasploit::Model::Search::Operation::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operation::Base }
 
   context 'validations' do
     context 'children' do
-      it { should ensure_length_of(:children).is_at_least(1).with_short_message('is too short (minimum is 1 child)') }
+      it { is_expected.to ensure_length_of(:children).is_at_least(1).with_short_message('is too short (minimum is 1 child)') }
 
       context '#children_valid' do
         subject(:children_valid) do

--- a/spec/app/models/metasploit/model/search/operation/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/intersection_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Group::Intersection, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Group::Intersection, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/operation/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/intersection_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Group::Intersection do
+describe Metasploit::Model::Search::Operation::Group::Intersection, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/operation/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/intersection_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe Metasploit::Model::Search::Operation::Group::Intersection, type: :model do
-  it { should be_a Metasploit::Model::Search::Operation::Group::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operation::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/operation/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/union_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe Metasploit::Model::Search::Operation::Group::Union, type: :model do
-  it { should be_a Metasploit::Model::Search::Operation::Group::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operation::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/operation/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/union_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Group::Union, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Group::Union, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/operation/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/union_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Group::Union do
+describe Metasploit::Model::Search::Operation::Group::Union, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Group::Base }
 end

--- a/spec/app/models/metasploit/model/search/operation/integer_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/integer_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Integer, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Integer, type: :model do
   context 'validation' do
     it { should validate_numericality_of(:value).only_integer }
   end

--- a/spec/app/models/metasploit/model/search/operation/integer_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/integer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Metasploit::Model::Search::Operation::Integer, type: :model do
   context 'validation' do
-    it { should validate_numericality_of(:value).only_integer }
+    it { is_expected.to validate_numericality_of(:value).only_integer }
   end
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::Integer'

--- a/spec/app/models/metasploit/model/search/operation/integer_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/integer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Integer do
+describe Metasploit::Model::Search::Operation::Integer, type: :model do
   context 'validation' do
     it { should validate_numericality_of(:value).only_integer }
   end

--- a/spec/app/models/metasploit/model/search/operation/null_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/null_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Null do
+describe Metasploit::Model::Search::Operation::Null, type: :model do
   context 'validation' do
     context 'operator' do
       context 'null' do

--- a/spec/app/models/metasploit/model/search/operation/null_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/null_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Null, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Null, type: :model do
   context 'validation' do
     context 'operator' do
       context 'null' do
@@ -41,7 +39,7 @@ describe Metasploit::Model::Search::Operation::Null, type: :model do
           end
 
           it 'should not record error' do
-            errors.should_not include(error)
+            expect(errors).not_to include(error)
           end
         end
 
@@ -51,11 +49,11 @@ describe Metasploit::Model::Search::Operation::Null, type: :model do
           end
 
           it 'should record error' do
-            errors.should include(error)
+            expect(errors).to include(error)
           end
 
           it 'should have no other errors, so that it would be valid without this type check on operator' do
-            operation.errors.size.should == 1
+            expect(operation.errors.size).to eq(1)
           end
         end
       end

--- a/spec/app/models/metasploit/model/search/operation/set/integer_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set/integer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Set::Integer do
+describe Metasploit::Model::Search::Operation::Set::Integer, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Set }
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::Integer'

--- a/spec/app/models/metasploit/model/search/operation/set/integer_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set/integer_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Metasploit::Model::Search::Operation::Set::Integer, type: :model do
-  it { should be_a Metasploit::Model::Search::Operation::Set }
+  it { is_expected.to be_a Metasploit::Model::Search::Operation::Set }
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::Integer'
 end

--- a/spec/app/models/metasploit/model/search/operation/set/integer_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set/integer_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Set::Integer, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Set::Integer, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Set }
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::Integer'

--- a/spec/app/models/metasploit/model/search/operation/set/string_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set/string_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Metasploit::Model::Search::Operation::Set::String, type: :model do
-  it { should be_a Metasploit::Model::Search::Operation::Set }
+  it { is_expected.to be_a Metasploit::Model::Search::Operation::Set }
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::String'
 end

--- a/spec/app/models/metasploit/model/search/operation/set/string_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set/string_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Set::String do
+describe Metasploit::Model::Search::Operation::Set::String, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Set }
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::String'

--- a/spec/app/models/metasploit/model/search/operation/set/string_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set/string_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Set::String, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Set::String, type: :model do
   it { should be_a Metasploit::Model::Search::Operation::Set }
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::String'

--- a/spec/app/models/metasploit/model/search/operation/set_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Metasploit::Model::Search::Operation::Set, type: :model do
               attribute_set.sample
             end
 
-            it { should_not include(error) }
+            it { is_expected.not_to include(error) }
           end
 
           context 'without value in attribute_set' do
@@ -103,7 +103,7 @@ RSpec.describe Metasploit::Model::Search::Operation::Set, type: :model do
               :not_an_member
             end
 
-            it { should include(error) }
+            it { is_expected.to include(error) }
           end
         end
 
@@ -116,7 +116,7 @@ RSpec.describe Metasploit::Model::Search::Operation::Set, type: :model do
             nil
           end
 
-          it { should_not include(error) }
+          it { is_expected.not_to include(error) }
         end
       end
     end

--- a/spec/app/models/metasploit/model/search/operation/set_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Set, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::Set, type: :model do
   subject(:set) do
     described_class.new(
         operator: operator,

--- a/spec/app/models/metasploit/model/search/operation/set_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/set_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::Set do
+describe Metasploit::Model::Search::Operation::Set, type: :model do
   subject(:set) do
     described_class.new(
         operator: operator,

--- a/spec/app/models/metasploit/model/search/operation/string_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/string_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::String, type: :model do
+RSpec.describe Metasploit::Model::Search::Operation::String, type: :model do
   context 'validation' do
     it { should validate_presence_of(:value) }
   end

--- a/spec/app/models/metasploit/model/search/operation/string_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/string_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operation::String do
+describe Metasploit::Model::Search::Operation::String, type: :model do
   context 'validation' do
     it { should validate_presence_of(:value) }
   end

--- a/spec/app/models/metasploit/model/search/operation/string_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/string_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Metasploit::Model::Search::Operation::String, type: :model do
   context 'validation' do
-    it { should validate_presence_of(:value) }
+    it { is_expected.to validate_presence_of(:value) }
   end
 
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::String'

--- a/spec/app/models/metasploit/model/search/operator/association_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/association_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Association, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Association, type: :model do
   subject(:operator) do
     described_class.new(
         :association => association,

--- a/spec/app/models/metasploit/model/search/operator/association_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/association_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Association do
+describe Metasploit::Model::Search::Operator::Association, type: :model do
   subject(:operator) do
     described_class.new(
         :association => association,

--- a/spec/app/models/metasploit/model/search/operator/association_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/association_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Metasploit::Model::Search::Operator::Association, type: :model do
     double('Metasploit::Model::Search::Operator::Base')
   end
 
-  it { should be_a Metasploit::Model::Search::Operator::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operator::Base }
 
   context 'validations' do
-    it { should validate_presence_of(:association) }
-    it { should validate_presence_of(:source_operator) }
+    it { is_expected.to validate_presence_of(:association) }
+    it { is_expected.to validate_presence_of(:source_operator) }
   end
 
   context '#help' do
@@ -49,7 +49,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Association, type: :model do
       'source_operator_name'
     }
 
-    it { should be_a Symbol }
+    it { is_expected.to be_a Symbol }
 
     it 'should be <association>.<source_operator.name>' do
       expect(name).to eq :"#{association}.#{source_operator_name}"
@@ -79,7 +79,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Association, type: :model do
       }
     }
 
-    it { should be_a Metasploit::Model::Search::Operation::Association }
+    it { is_expected.to be_a Metasploit::Model::Search::Operation::Association }
 
     context 'Metasploit::Model::Search::Operation::Association' do
       context '#operator' do

--- a/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Metasploit::Model::Search::Operator::Attribute, type: :model do
-  it { should be_a Metasploit::Model::Search::Operator::Single }
+  it { is_expected.to be_a Metasploit::Model::Search::Operator::Single }
 
   context 'CONSTANTS' do
     context 'TYPES' do
@@ -7,30 +7,30 @@ RSpec.describe Metasploit::Model::Search::Operator::Attribute, type: :model do
         described_class::TYPES
       end
 
-      it { should include(:boolean) }
-      it { should include(:date) }
+      it { is_expected.to include(:boolean) }
+      it { is_expected.to include(:date) }
       it {
-        should include(
+        is_expected.to include(
                    {
                        set: :integer
                    }
                )
       }
       it {
-        should include(
+        is_expected.to include(
                    {
                        set: :string
                    }
                )
       }
-      it { should include(:integer) }
-      it { should include(:string) }
+      it { is_expected.to include(:integer) }
+      it { is_expected.to include(:string) }
     end
   end
 
   context 'validations' do
-    it { should validate_presence_of(:attribute) }
-    it { should ensure_inclusion_of(:type).in_array(described_class::TYPES) }
+    it { is_expected.to validate_presence_of(:attribute) }
+    it { is_expected.to ensure_inclusion_of(:type).in_array(described_class::TYPES) }
   end
 
   context '#attribute_enumerable' do

--- a/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Attribute do
+describe Metasploit::Model::Search::Operator::Attribute, type: :model do
   it { should be_a Metasploit::Model::Search::Operator::Single }
 
   context 'CONSTANTS' do

--- a/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Attribute, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Attribute, type: :model do
   it { should be_a Metasploit::Model::Search::Operator::Single }
 
   context 'CONSTANTS' do
@@ -77,7 +75,7 @@ describe Metasploit::Model::Search::Operator::Attribute, type: :model do
       end
 
       it 'should be #klass #<attribute>_set' do
-        attribute_set.should == expected_attribute_set
+        expect(attribute_set).to eq(expected_attribute_set)
       end
     end
   end
@@ -98,7 +96,7 @@ describe Metasploit::Model::Search::Operator::Attribute, type: :model do
     end
 
     it 'should be #attribute' do
-      name.should == attribute
+      expect(name).to eq(attribute)
     end
   end
 end

--- a/spec/app/models/metasploit/model/search/operator/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/base_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Base, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Base, type: :model do
   subject(:operator) do
     described_class.new
   end
@@ -12,7 +10,7 @@ describe Metasploit::Model::Search::Operator::Base, type: :model do
 
     before(:each) do
       # have to stub since it's not implemented on base
-      operator.stub(name: name)
+      allow(operator).to receive(:name).and_return(name)
     end
   end
 

--- a/spec/app/models/metasploit/model/search/operator/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/base_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Base do
+describe Metasploit::Model::Search::Operator::Base, type: :model do
   subject(:operator) do
     described_class.new
   end

--- a/spec/app/models/metasploit/model/search/operator/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/base_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Base, type: :model do
   end
 
   context 'validations' do
-    it { should validate_presence_of(:klass) }
+    it { is_expected.to validate_presence_of(:klass) }
   end
 
   context '#name' do

--- a/spec/app/models/metasploit/model/search/operator/delegation_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/delegation_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Delegation, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Delegation, type: :model do
   subject(:operator) do
     described_class.new(
         :klass => klass
@@ -32,7 +30,7 @@ describe Metasploit::Model::Search::Operator::Delegation, type: :model do
       end
 
       it 'should remove namespace' do
-        operator_name.should == base_name.downcase.to_sym
+        expect(operator_name).to eq(base_name.downcase.to_sym)
       end
     end
 
@@ -42,7 +40,7 @@ describe Metasploit::Model::Search::Operator::Delegation, type: :model do
       end
 
       it 'should convert name to underscore' do
-        operator_name.should == :camel_case
+        expect(operator_name).to eq(:camel_case)
       end
     end
   end
@@ -67,17 +65,21 @@ describe Metasploit::Model::Search::Operator::Delegation, type: :model do
     end
 
     before(:each) do
-      klass.stub(:search_operator_by_name => search_operator_by_name)
+      outer_search_operator_by_name = search_operator_by_name
+
+      klass.send(:define_singleton_method, :search_operator_by_name) do
+        outer_search_operator_by_name
+      end
     end
 
     it 'should convert formatted_operator to Symbol' do
-      formatted_operator.should_receive(:to_sym)
+      expect(formatted_operator).to receive(:to_sym)
 
       named_operator
     end
 
     it 'should look up operator name in search_operator_by_name of #klass' do
-      named_operator.should == search_operator
+      expect(named_operator).to eq(search_operator)
     end
 
     context 'with name not in klass.search_operator_by_name' do
@@ -100,9 +102,9 @@ describe Metasploit::Model::Search::Operator::Delegation, type: :model do
 
     it 'should delegate to operator_name' do
       operator_name = double('Operator Name')
-      operator.class.stub(:operator_name => operator_name)
+      allow(operator.class).to receive(:operator_name).and_return(operator_name)
 
-      name.should == operator_name
+      expect(name).to eq(operator_name)
     end
   end
 end

--- a/spec/app/models/metasploit/model/search/operator/delegation_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/delegation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Delegation do
+describe Metasploit::Model::Search::Operator::Delegation, type: :model do
   subject(:operator) do
     described_class.new(
         :klass => klass

--- a/spec/app/models/metasploit/model/search/operator/delegation_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/delegation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Delegation, type: :model do
     Class.new
   end
 
-  it { should be_a Metasploit::Model::Search::Operator::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operator::Base }
 
   context 'operator_name' do
     subject(:operator_name) do

--- a/spec/app/models/metasploit/model/search/operator/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/base_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Group::Base do
+describe Metasploit::Model::Search::Operator::Group::Base, type: :model do
   subject(:operator) do
     described_class.new
   end

--- a/spec/app/models/metasploit/model/search/operator/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/base_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Group::Base, type: :model do
       allow(operator).to receive(:children).and_return(children)
     end
 
-    it { should be_a Metasploit::Model::Search::Operation::Group::Base }
+    it { is_expected.to be_a Metasploit::Model::Search::Operation::Group::Base }
 
     context 'children' do
       subject(:operation_children) do

--- a/spec/app/models/metasploit/model/search/operator/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/base_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Group::Base, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Group::Base, type: :model do
   subject(:operator) do
     described_class.new
   end
@@ -50,7 +48,7 @@ describe Metasploit::Model::Search::Operator::Group::Base, type: :model do
     #
 
     before(:each) do
-      operator.stub(:children => children)
+      allow(operator).to receive(:children).and_return(children)
     end
 
     it { should be_a Metasploit::Model::Search::Operation::Group::Base }
@@ -75,7 +73,7 @@ describe Metasploit::Model::Search::Operator::Group::Base, type: :model do
       end
 
       it 'should be the operator itself' do
-        operation_operator.should == operator
+        expect(operation_operator).to eq(operator)
       end
     end
 
@@ -85,7 +83,7 @@ describe Metasploit::Model::Search::Operator::Group::Base, type: :model do
       end
 
       it 'should be formatted value' do
-        value.should == formatted_value
+        expect(value).to eq(formatted_value)
       end
     end
   end

--- a/spec/app/models/metasploit/model/search/operator/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/intersection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Group::Intersection do
+describe Metasploit::Model::Search::Operator::Group::Intersection, type: :model do
   it { should be_a Metasploit::Model::Search::Operator::Group::Base }
 
   context 'operation_class_name' do

--- a/spec/app/models/metasploit/model/search/operator/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/intersection_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Metasploit::Model::Search::Operator::Group::Intersection, type: :model do
-  it { should be_a Metasploit::Model::Search::Operator::Group::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operator::Group::Base }
 
   context 'operation_class_name' do
     subject(:operation_class_name) {

--- a/spec/app/models/metasploit/model/search/operator/group/intersection_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/intersection_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Group::Intersection, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Group::Intersection, type: :model do
   it { should be_a Metasploit::Model::Search::Operator::Group::Base }
 
   context 'operation_class_name' do
@@ -8,6 +6,6 @@ describe Metasploit::Model::Search::Operator::Group::Intersection, type: :model 
       described_class.operation_class_name
     }
 
-    it { should == 'Metasploit::Model::Search::Operation::Group::Intersection' }
+    it { is_expected.to eq('Metasploit::Model::Search::Operation::Group::Intersection') }
   end
 end

--- a/spec/app/models/metasploit/model/search/operator/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/union_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Group::Union do
+describe Metasploit::Model::Search::Operator::Group::Union, type: :model do
   it { should be_a Metasploit::Model::Search::Operator::Group::Base }
 
   context 'operation_class_name' do

--- a/spec/app/models/metasploit/model/search/operator/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/union_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Group::Union, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Group::Union, type: :model do
   it { should be_a Metasploit::Model::Search::Operator::Group::Base }
 
   context 'operation_class_name' do
@@ -8,6 +6,6 @@ describe Metasploit::Model::Search::Operator::Group::Union, type: :model do
       described_class.operation_class_name
     }
 
-    it { should == 'Metasploit::Model::Search::Operation::Group::Union' }
+    it { is_expected.to eq('Metasploit::Model::Search::Operation::Group::Union') }
   end
 end

--- a/spec/app/models/metasploit/model/search/operator/group/union_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/group/union_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Metasploit::Model::Search::Operator::Group::Union, type: :model do
-  it { should be_a Metasploit::Model::Search::Operator::Group::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operator::Group::Base }
 
   context 'operation_class_name' do
     subject(:operation_class_name) {

--- a/spec/app/models/metasploit/model/search/operator/null_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/null_spec.rb
@@ -1,11 +1,9 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Null, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Null, type: :model do
   subject(:operator) do
     described_class.new
   end
 
-  it { should be_a Metasploit::Model::Search::Operator::Single }
+  it { is_expected.to be_a Metasploit::Model::Search::Operator::Single }
 
   context 'validations' do
     context 'name' do
@@ -18,7 +16,7 @@ describe Metasploit::Model::Search::Operator::Null, type: :model do
       end
 
       it 'should record error' do
-        operator.errors[:name].should include(error)
+        expect(operator.errors[:name]).to include(error)
       end
     end
   end
@@ -28,7 +26,7 @@ describe Metasploit::Model::Search::Operator::Null, type: :model do
       operator.type
     end
 
-    it { should be_nil }
+    it { is_expected.to be_nil }
   end
 
   context '#operation_class' do
@@ -36,6 +34,6 @@ describe Metasploit::Model::Search::Operator::Null, type: :model do
       operator.send(:operation_class)
     end
 
-    it { should == Metasploit::Model::Search::Operation::Null }
+    it { is_expected.to eq(Metasploit::Model::Search::Operation::Null) }
   end
 end

--- a/spec/app/models/metasploit/model/search/operator/null_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/null_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Null do
+describe Metasploit::Model::Search::Operator::Null, type: :model do
   subject(:operator) do
     described_class.new
   end

--- a/spec/app/models/metasploit/model/search/operator/single_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/single_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Single, type: :model do
+RSpec.describe Metasploit::Model::Search::Operator::Single, type: :model do
   subject(:operator) do
     described_class.new
   end
@@ -13,7 +11,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
         described_class::MODULE_SEPARATOR
       end
 
-      it { should == '::' }
+      it { is_expected.to eq('::') }
     end
 
     context 'OPERATION_NAMESPACE_NAME' do
@@ -21,7 +19,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
         described_class::OPERATION_NAMESPACE_NAME
       end
 
-      it { should == 'Metasploit::Model::Search::Operation' }
+      it { is_expected.to eq('Metasploit::Model::Search::Operation') }
     end
   end
 
@@ -67,7 +65,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
         end
 
         it 'should be the constant_name of the key and value separated by MODULE_SEPARATOR' do
-          constant_name.should == "#{key_constant_name}#{described_class::MODULE_SEPARATOR}#{value_constant_name}"
+          expect(constant_name).to eq("#{key_constant_name}#{described_class::MODULE_SEPARATOR}#{value_constant_name}")
         end
       end
 
@@ -93,7 +91,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
       end
 
       it 'should constantize string version of Symbol' do
-        constant_name.should == 'Integer'
+        expect(constant_name).to eq('Integer')
       end
     end
 
@@ -124,20 +122,20 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
     end
 
     before(:each) do
-      operator.stub(:operation_class => operation_class)
+      allow(operator).to receive(:operation_class).and_return(operation_class)
     end
 
     it 'should call new on #operation_class' do
-      operation_class.should_receive(:new).with(:value => formatted_value, :operator => operator)
+      expect(operation_class).to receive(:new).with(:value => formatted_value, :operator => operator)
 
       operate_on
     end
 
     it 'should return instance of #operation_class' do
       operation = double('Operation')
-      operation_class.stub(:new => operation)
+      allow(operation_class).to receive(:new).and_return(operation)
 
-      operate_on.should == operation
+      expect(operate_on).to eq(operation)
     end
   end
 
@@ -147,7 +145,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
     end
 
     before(:each) do
-      operator.stub(:type => type)
+      allow(operator).to receive(:type).and_return(type)
     end
 
     context 'type' do
@@ -156,7 +154,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :boolean
         end
 
-        it { should == Metasploit::Model::Search::Operation::Boolean }
+        it { is_expected.to eq(Metasploit::Model::Search::Operation::Boolean) }
       end
 
       context 'with :date' do
@@ -164,7 +162,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :date
         end
 
-        it { should == Metasploit::Model::Search::Operation::Date }
+        it { is_expected.to eq(Metasploit::Model::Search::Operation::Date) }
       end
 
       context 'with set: :integer' do
@@ -174,7 +172,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           }
         end
 
-        it { should == Metasploit::Model::Search::Operation::Set::Integer }
+        it { is_expected.to eq(Metasploit::Model::Search::Operation::Set::Integer) }
       end
 
       context 'with set: :string' do
@@ -184,7 +182,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           }
         end
 
-        it { should == Metasploit::Model::Search::Operation::Set::String }
+        it { is_expected.to eq(Metasploit::Model::Search::Operation::Set::String) }
       end
 
       context 'with :integer' do
@@ -192,7 +190,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :integer
         end
 
-        it { should == Metasploit::Model::Search::Operation::Integer }
+        it { is_expected.to eq(Metasploit::Model::Search::Operation::Integer) }
       end
 
       context 'with :string' do
@@ -200,7 +198,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :string
         end
 
-        it { should == Metasploit::Model::Search::Operation::String }
+        it { is_expected.to eq(Metasploit::Model::Search::Operation::String) }
       end
 
       context 'with nil' do
@@ -213,7 +211,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
         end
 
         before(:each) do
-          operator.stub(:name => name)
+          allow(operator).to receive(:name).and_return(name)
         end
 
         it 'should raise ArgumentError' do
@@ -233,7 +231,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
     end
 
     before(:each) do
-      operator.stub(:type => type)
+      allow(operator).to receive(:type).and_return(type)
     end
 
     context 'type' do
@@ -242,7 +240,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :boolean
         end
 
-        it { should == 'Metasploit::Model::Search::Operation::Boolean' }
+        it { is_expected.to eq('Metasploit::Model::Search::Operation::Boolean') }
       end
 
       context 'with :date' do
@@ -250,7 +248,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :date
         end
 
-        it { should == 'Metasploit::Model::Search::Operation::Date' }
+        it { is_expected.to eq('Metasploit::Model::Search::Operation::Date') }
       end
 
       context 'with set: :integer' do
@@ -260,7 +258,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           }
         end
 
-        it { should == 'Metasploit::Model::Search::Operation::Set::Integer' }
+        it { is_expected.to eq('Metasploit::Model::Search::Operation::Set::Integer') }
       end
 
       context 'with set: :string' do
@@ -270,7 +268,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           }
         end
 
-        it { should == 'Metasploit::Model::Search::Operation::Set::String' }
+        it { is_expected.to eq('Metasploit::Model::Search::Operation::Set::String') }
       end
 
       context 'with :integer' do
@@ -278,7 +276,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :integer
         end
 
-        it { should == 'Metasploit::Model::Search::Operation::Integer' }
+        it { is_expected.to eq('Metasploit::Model::Search::Operation::Integer') }
       end
 
       context 'with :string' do
@@ -286,7 +284,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
           :string
         end
 
-        it { should == 'Metasploit::Model::Search::Operation::String' }
+        it { is_expected.to eq('Metasploit::Model::Search::Operation::String') }
       end
 
       context 'with nil' do
@@ -299,7 +297,7 @@ describe Metasploit::Model::Search::Operator::Single, type: :model do
         end
 
         before(:each) do
-          operator.stub(:name => name)
+          allow(operator).to receive(:name).and_return(name)
         end
 
         it 'should raise ArgumentError' do

--- a/spec/app/models/metasploit/model/search/operator/single_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/single_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Single, type: :model do
     described_class.new
   end
 
-  it { should be_a Metasploit::Model::Search::Operator::Base }
+  it { is_expected.to be_a Metasploit::Model::Search::Operator::Base }
 
   context 'CONSTANTS' do
     context 'MODULE_SEPARATOR' do

--- a/spec/app/models/metasploit/model/search/operator/single_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/single_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Operator::Single do
+describe Metasploit::Model::Search::Operator::Single, type: :model do
   subject(:operator) do
     described_class.new
   end

--- a/spec/app/models/metasploit/model/search/query_spec.rb
+++ b/spec/app/models/metasploit/model/search/query_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Search::Query do
+describe Metasploit::Model::Search::Query, type: :model do
   context 'validations' do
     it { should validate_presence_of :klass }
 

--- a/spec/app/models/metasploit/model/search/query_spec.rb
+++ b/spec/app/models/metasploit/model/search/query_spec.rb
@@ -1,8 +1,6 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Query, type: :model do
+RSpec.describe Metasploit::Model::Search::Query, type: :model do
   context 'validations' do
-    it { should validate_presence_of :klass }
+    it { is_expected.to validate_presence_of :klass }
 
     context 'operations' do
       let(:errors) do
@@ -45,11 +43,11 @@ describe Metasploit::Model::Search::Query, type: :model do
           end
 
           it 'should have no operations' do
-            query.operations.length.should == 0
+            expect(query.operations.length).to eq(0)
           end
 
           it 'should record error on operations' do
-            errors.should include(error)
+            expect(errors).to include(error)
           end
         end
 
@@ -59,7 +57,7 @@ describe Metasploit::Model::Search::Query, type: :model do
           end
 
           it 'should not record error on operations' do
-            errors.should_not include(error)
+            expect(errors).not_to include(error)
           end
         end
       end
@@ -75,7 +73,7 @@ describe Metasploit::Model::Search::Query, type: :model do
 
         before(:each) do
           operation = double('Invalid Operation', :valid? => valid)
-          query.stub(:operations).and_return([operation])
+          allow(query).to receive(:operations).and_return([operation])
         end
 
         context 'with invalid operation' do
@@ -84,7 +82,7 @@ describe Metasploit::Model::Search::Query, type: :model do
           end
 
           it 'should record error on operations' do
-            errors.should_not include(error)
+            expect(errors).not_to include(error)
           end
         end
 
@@ -94,7 +92,7 @@ describe Metasploit::Model::Search::Query, type: :model do
           end
 
           it 'should not record error on options' do
-            errors.should_not include(error)
+            expect(errors).not_to include(error)
           end
         end
       end
@@ -117,11 +115,11 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should include operation with space in value' do
-        formatted_operations.should include('formatted_operator1:formatted value:1')
+        expect(formatted_operations).to include('formatted_operator1:formatted value:1')
       end
 
       it 'should include operation without space in value' do
-        formatted_operations.should include('formatted_operator2:formatted_value2')
+        expect(formatted_operations).to include('formatted_operator2:formatted_value2')
       end
     end
 
@@ -172,7 +170,7 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should equal attribute passed to #initialize' do
-        formatted_operations.should == expected_formatted_operations
+        expect(formatted_operations).to eq(expected_formatted_operations)
       end
     end
 
@@ -208,7 +206,7 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should parse #formatted with formatted_operations' do
-        described_class.should_receive(:formatted_operations).with(formatted).and_return([])
+        expect(described_class).to receive(:formatted_operations).with(formatted).and_return([])
 
         formatted_operations
       end
@@ -232,7 +230,7 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should use attribute passed to #initialize' do
-        operations.should == expected_operations
+        expect(operations).to eq(expected_operations)
       end
     end
 
@@ -272,7 +270,7 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should call #formatted_operations' do
-        query.should_receive(:formatted_operations).and_return([])
+        expect(query).to receive(:formatted_operations).and_return([])
 
         operations
       end
@@ -299,14 +297,14 @@ describe Metasploit::Model::Search::Query, type: :model do
             :boolean
           end
 
-          it { should be_a Metasploit::Model::Search::Operation::Boolean }
+          it { is_expected.to be_a Metasploit::Model::Search::Operation::Boolean }
 
           context "with 'true'" do
             let(:formatted_value) do
               'true'
             end
 
-            it { should be_valid }
+            it { is_expected.to be_valid }
           end
 
           context "with 'false'" do
@@ -314,7 +312,7 @@ describe Metasploit::Model::Search::Query, type: :model do
               'false'
             end
 
-            it { should be_valid }
+            it { is_expected.to be_valid }
           end
 
           context "without 'false' or 'true'" do
@@ -322,7 +320,7 @@ describe Metasploit::Model::Search::Query, type: :model do
               'no'
             end
 
-            it { should_not be_valid }
+            it { is_expected.to_not be_valid }
           end
         end
 
@@ -331,14 +329,14 @@ describe Metasploit::Model::Search::Query, type: :model do
             :date
           end
 
-          it { should be_a Metasploit::Model::Search::Operation::Date }
+          it { is_expected.to be_a Metasploit::Model::Search::Operation::Date }
 
           context 'with date' do
             let(:formatted_value) do
               Date.today.to_s
             end
 
-            it { should be_valid }
+            it { is_expected.to be_valid }
           end
 
           context 'without date' do
@@ -346,7 +344,7 @@ describe Metasploit::Model::Search::Query, type: :model do
               'yesterday'
             end
 
-            it { should_not be_valid }
+            it { is_expected.to_not be_valid }
           end
         end
 
@@ -355,14 +353,14 @@ describe Metasploit::Model::Search::Query, type: :model do
             :integer
           end
 
-          it { should be_a Metasploit::Model::Search::Operation::Integer }
+          it { is_expected.to be_a Metasploit::Model::Search::Operation::Integer }
 
           context 'with integer' do
             let(:formatted_value) do
               '100'
             end
 
-            it { should be_valid }
+            it { is_expected.to be_valid }
           end
 
           context 'with float' do
@@ -370,7 +368,7 @@ describe Metasploit::Model::Search::Query, type: :model do
               '100.5'
             end
 
-            it { should be_invalid }
+            it { is_expected.to be_invalid }
           end
 
           context 'with integer embedded in text' do
@@ -378,7 +376,7 @@ describe Metasploit::Model::Search::Query, type: :model do
               'a2c'
             end
 
-            it { should be_invalid }
+            it { is_expected.to be_invalid }
           end
         end
 
@@ -387,14 +385,14 @@ describe Metasploit::Model::Search::Query, type: :model do
             :string
           end
 
-          it { should be_a Metasploit::Model::Search::Operation::String }
+          it { is_expected.to be_a Metasploit::Model::Search::Operation::String }
 
           context 'with value' do
             let(:formatted_value) do
               'formatted_value'
             end
 
-            it { should be_valid }
+            it { is_expected.to be_valid }
           end
 
           context 'without value' do
@@ -402,7 +400,7 @@ describe Metasploit::Model::Search::Query, type: :model do
               ''
             end
 
-            it { should_not be_valid }
+            it { is_expected.to_not be_valid }
           end
         end
       end
@@ -420,9 +418,9 @@ describe Metasploit::Model::Search::Query, type: :model do
           'unknown_value'
         end
 
-        it { should be_a Metasploit::Model::Search::Operation::Base }
+        it { is_expected.to be_a Metasploit::Model::Search::Operation::Base }
 
-        it { should be_invalid }
+        it { is_expected.to be_invalid }
       end
     end
   end
@@ -468,7 +466,7 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should have correct number of groups' do
-        operations_by_operator.length.should == @operators.length
+        expect(operations_by_operator.length).to eq(@operators.length)
       end
 
       it 'should have correct value for each operator' do
@@ -489,7 +487,7 @@ describe Metasploit::Model::Search::Query, type: :model do
           query
         end
 
-        it { should be_valid }
+        it { is_expected.to be_valid }
       end
     end
 
@@ -503,7 +501,7 @@ describe Metasploit::Model::Search::Query, type: :model do
           query
         end
 
-        it { should_not be_valid }
+        it { is_expected.to_not be_valid }
       end
     end
   end
@@ -542,7 +540,7 @@ describe Metasploit::Model::Search::Query, type: :model do
 
       context 'with String' do
         it 'should find operator' do
-          parse_operator.should == @operator
+          expect(parse_operator).to eq(@operator)
         end
       end
 
@@ -552,7 +550,7 @@ describe Metasploit::Model::Search::Query, type: :model do
         end
 
         it 'should find operator' do
-          parse_operator.should == @operator
+          expect(parse_operator).to eq(@operator)
         end
       end
     end
@@ -562,7 +560,7 @@ describe Metasploit::Model::Search::Query, type: :model do
         'unknown_operator'
       end
 
-      it { should be_a Metasploit::Model::Search::Operator::Null }
+      it { is_expected.to be_a Metasploit::Model::Search::Operator::Null }
     end
   end
 
@@ -599,7 +597,7 @@ describe Metasploit::Model::Search::Query, type: :model do
         tree
       end
 
-      it { should be_a Metasploit::Model::Search::Group::Intersection }
+      it { is_expected.to be_a Metasploit::Model::Search::Group::Intersection }
 
       context 'children' do
         subject(:children) do
@@ -608,7 +606,7 @@ describe Metasploit::Model::Search::Query, type: :model do
 
         it 'should be an Array<Metasploit::Model::Search::Group::Union>' do
           children.each do |child|
-            child.should be_a Metasploit::Model::Search::Group::Union
+            expect(child).to be_a Metasploit::Model::Search::Group::Union
           end
         end
 
@@ -618,7 +616,7 @@ describe Metasploit::Model::Search::Query, type: :model do
               operator_set.add operation.operator
             }
 
-            operator_set.length.should == 1
+            expect(operator_set.length).to eq(1)
           end
         end
 
@@ -635,7 +633,7 @@ describe Metasploit::Model::Search::Query, type: :model do
 
           it 'should be Array<Metasploit::Model::Search::Operation::Base>' do
             grandchildren.each do |grandchild|
-              grandchild.should be_a Metasploit::Model::Search::Operation::Base
+              expect(grandchild).to be_a Metasploit::Model::Search::Operation::Base
             end
           end
         end
@@ -701,15 +699,15 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should return a new query' do
-        without_operator.should_not be query
+        expect(without_operator).not_to be query
       end
 
       it 'should not have operations on the removed operator' do
-        without_operator.operations_by_operator[filtered_operator].should be_blank
+        expect(without_operator.operations_by_operator[filtered_operator]).to be_blank
       end
 
       it 'should have same #klass as this query' do
-        without_operator.klass.should == query.klass
+        expect(without_operator.klass).to eq(query.klass)
       end
 
       context 'with no other operators' do
@@ -719,11 +717,11 @@ describe Metasploit::Model::Search::Query, type: :model do
           ]
         end
 
-        it { should_not be_valid }
+        it { is_expected.to_not be_valid }
       end
 
       context 'with other operators' do
-        it { should be_valid }
+        it { is_expected.to be_valid }
       end
     end
 
@@ -735,7 +733,7 @@ describe Metasploit::Model::Search::Query, type: :model do
       end
 
       it 'should return this query' do
-        without_operator.should be query
+        expect(without_operator).to be query
       end
     end
   end

--- a/spec/app/models/metasploit/model/search/query_spec.rb
+++ b/spec/app/models/metasploit/model/search/query_spec.rb
@@ -612,8 +612,8 @@ RSpec.describe Metasploit::Model::Search::Query, type: :model do
 
         it 'should have same operator for each child of a union' do
           children.each do |child|
-            operator_set = child.children.inject(Set.new) { |operator_set, operation|
-              operator_set.add operation.operator
+            operator_set = child.children.inject(Set.new) { |block_operator_set, operation|
+              block_operator_set.add operation.operator
             }
 
             expect(operator_set.length).to eq(1)

--- a/spec/app/models/metasploit/model/visitation/visitor_spec.rb
+++ b/spec/app/models/metasploit/model/visitation/visitor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Model::Visitation::Visitor do
+describe Metasploit::Model::Visitation::Visitor, type: :model do
   context 'validations' do
     it { should validate_presence_of :block }
     it { should validate_presence_of :module_name }

--- a/spec/app/models/metasploit/model/visitation/visitor_spec.rb
+++ b/spec/app/models/metasploit/model/visitation/visitor_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Visitation::Visitor, type: :model do
+RSpec.describe Metasploit::Model::Visitation::Visitor, type: :model do
   context 'validations' do
     it { should validate_presence_of :block }
     it { should validate_presence_of :module_name }
@@ -31,15 +29,15 @@ describe Metasploit::Model::Visitation::Visitor, type: :model do
     end
 
     it 'should set #block from &block' do
-      instance.block.should == block
+      expect(instance.block).to eq(block)
     end
 
     it 'should set #module_name from :module_name' do
-      instance.module_name.should == module_name
+      expect(instance.module_name).to eq(module_name)
     end
 
     it 'should set #parent from :parent' do
-      instance.parent.should == parent
+      expect(instance.parent).to eq(parent)
     end
   end
 end

--- a/spec/app/models/metasploit/model/visitation/visitor_spec.rb
+++ b/spec/app/models/metasploit/model/visitation/visitor_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Metasploit::Model::Visitation::Visitor, type: :model do
   context 'validations' do
-    it { should validate_presence_of :block }
-    it { should validate_presence_of :module_name }
-    it { should validate_presence_of :parent }
+    it { is_expected.to validate_presence_of :block }
+    it { is_expected.to validate_presence_of :module_name }
+    it { is_expected.to validate_presence_of :parent }
   end
 
   context '#initialize' do

--- a/spec/app/validators/ip_format_validator_spec.rb
+++ b/spec/app/validators/ip_format_validator_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe IpFormatValidator do
+RSpec.describe IpFormatValidator do
   subject(:ip_format_validator) do
     described_class.new(
         :attributes => attributes
@@ -55,7 +53,7 @@ describe IpFormatValidator do
         it 'should not record any errors' do
           validate_each
 
-          record.errors.should be_empty
+          expect(record.errors).to be_empty
         end
       end
 
@@ -67,7 +65,7 @@ describe IpFormatValidator do
         it 'should not record any errors' do
           validate_each
 
-          record.errors.should be_empty
+          expect(record.errors).to be_empty
         end
       end
 
@@ -79,7 +77,7 @@ describe IpFormatValidator do
         it 'should record error' do
           validate_each
 
-          record.errors[attribute].should include("#{error} and not an IPv4 address range in CIDR or netmask notation")
+          expect(record.errors[attribute]).to include("#{error} and not an IPv4 address range in CIDR or netmask notation")
         end
       end
 
@@ -91,7 +89,7 @@ describe IpFormatValidator do
         it 'should record error' do
           validate_each
 
-          record.errors[attribute].should include("#{error} and not an IPv6 address range in CIDR or netmask notation")
+          expect(record.errors[attribute]).to include("#{error} and not an IPv6 address range in CIDR or netmask notation")
         end
       end
 
@@ -103,7 +101,7 @@ describe IpFormatValidator do
         it 'should record error' do
           validate_each
 
-          record.errors[attribute].should include(error)
+          expect(record.errors[attribute]).to include(error)
         end
       end
 
@@ -117,7 +115,7 @@ describe IpFormatValidator do
       it 'should record error on attribute' do
         validate_each
 
-        record.errors[attribute].should include(error)
+        expect(record.errors[attribute]).to include(error)
       end
     end
   end

--- a/spec/app/validators/nil_validator_spec.rb
+++ b/spec/app/validators/nil_validator_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe NilValidator do
+RSpec.describe NilValidator do
   subject(:nil_validator) do
     described_class.new(
         :attributes => attributes
@@ -50,7 +48,7 @@ describe NilValidator do
       it 'should record error on attribute' do
         validate_each
 
-        record.errors[attribute].should include('must be nil')
+        expect(record.errors[attribute]).to include('must be nil')
       end
     end
 
@@ -62,7 +60,7 @@ describe NilValidator do
       it 'should not record any error' do
         validate_each
 
-        record.errors.should be_empty
+        expect(record.errors).to be_empty
       end
     end
   end

--- a/spec/app/validators/parameters_validator_spec.rb
+++ b/spec/app/validators/parameters_validator_spec.rb
@@ -327,9 +327,11 @@ describe ParametersValidator do
       end
 
       it 'should error that attribute is not an array' do
-        errors.any? { |error|
-          error.include? 'is not an Array.'
-        }.should be_true
+        expect(
+            errors.any? { |error|
+              error.include? 'is not an Array.'
+            }
+        ).to eq(true)
       end
 
       it 'should include TYPE_SIGNATURE_SENTENCE' do

--- a/spec/app/validators/parameters_validator_spec.rb
+++ b/spec/app/validators/parameters_validator_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe ParametersValidator do
+RSpec.describe ParametersValidator do
   subject(:parameters_validator) do
     described_class.new(
         :attributes => attributes
@@ -29,7 +27,7 @@ describe ParametersValidator do
 
   context 'CONSTANTS' do
     it 'should define TYPE_SIGNATURE_SENTENCE' do
-      described_class::TYPE_SIGNATURE_SENTENCE.should == type_signature_sentence
+      expect(described_class::TYPE_SIGNATURE_SENTENCE).to eq(type_signature_sentence)
     end
   end
 
@@ -48,7 +46,7 @@ describe ParametersValidator do
     end
 
     it 'should include prefix' do
-      error_at.should include(prefix)
+      expect(error_at).to include(prefix)
     end
 
     it 'should include location_clause in same sentence as prefix' do
@@ -58,11 +56,11 @@ describe ParametersValidator do
           :index => index
       )
 
-      error_at.should include("#{prefix} #{location_clause}.")
+      expect(error_at).to include("#{prefix} #{location_clause}.")
     end
 
     it 'should include TYPE_SIGNATURE_SENTENCE' do
-      error_at.should include(type_signature_sentence)
+      expect(error_at).to include(type_signature_sentence)
     end
   end
 
@@ -81,9 +79,9 @@ describe ParametersValidator do
     end
 
     it 'should include extreme in prefix' do
-      parameters_validator.should_receive(:error_at) do |*args|
+      expect(parameters_validator).to receive(:error_at) do |*args|
         options = args.first
-        options[:prefix].should include(extreme.to_s)
+        expect(options[:prefix]).to include(extreme.to_s)
       end
 
       length_error_at
@@ -100,11 +98,11 @@ describe ParametersValidator do
     end
 
     it 'should include numerical index' do
-      location_clause.should include("at index #{index}")
+      expect(location_clause).to include("at index #{index}")
     end
 
     it 'should include inspect of element' do
-      location_clause.should include(element.inspect)
+      expect(location_clause).to include(element.inspect)
     end
   end
 
@@ -144,7 +142,7 @@ describe ParametersValidator do
             end
 
             it 'should call #length_error_at with :extreme => :few' do
-              parameters_validator.should_receive(:length_error_at).with(
+              expect(parameters_validator).to receive(:length_error_at).with(
                   hash_including(
                       :extreme => :few
                   )
@@ -156,7 +154,7 @@ describe ParametersValidator do
             it 'should record error' do
               validate_each
 
-              errors.should_not be_empty
+              expect(errors).not_to be_empty
             end
           end
 
@@ -166,7 +164,7 @@ describe ParametersValidator do
             end
 
             it 'should call #length_error_at with :extreme => :many' do
-              parameters_validator.should_receive(:length_error_at).with(
+              expect(parameters_validator).to receive(:length_error_at).with(
                   hash_including(
                       :extreme => :many
                   )
@@ -178,7 +176,7 @@ describe ParametersValidator do
             it 'should record error' do
               validate_each
 
-              errors.should_not be_empty
+              expect(errors).not_to be_empty
             end
           end
 
@@ -203,7 +201,7 @@ describe ParametersValidator do
                   end
 
                   it 'should call error_at with blank parameter name prefix' do
-                    parameters_validator.should_receive(:error_at).with(
+                    expect(parameters_validator).to receive(:error_at).with(
                         hash_including(
                           :prefix => 'has blank parameter name'
                         )
@@ -215,7 +213,7 @@ describe ParametersValidator do
                   it 'should record error' do
                     validate_each
 
-                    errors.should_not be_empty
+                    expect(errors).not_to be_empty
                   end
                 end
 
@@ -227,7 +225,7 @@ describe ParametersValidator do
                   it 'should not record error' do
                     validate_each
 
-                    errors.should be_blank
+                    expect(errors).to be_blank
                   end
                 end
               end
@@ -238,7 +236,7 @@ describe ParametersValidator do
                 end
 
                 it 'should call error_at with non-String prefix' do
-                  parameters_validator.should_receive(:error_at).with(
+                  expect(parameters_validator).to receive(:error_at).with(
                       hash_including(
                           :prefix => "has non-String parameter name (#{parameter_name.inspect})"
                       )
@@ -250,7 +248,7 @@ describe ParametersValidator do
                 it 'should record error' do
                   validate_each
 
-                  errors.should_not be_empty
+                  expect(errors).not_to be_empty
                 end
               end
             end
@@ -264,7 +262,7 @@ describe ParametersValidator do
                 it 'should not record error' do
                   validate_each
 
-                  errors.should be_blank
+                  expect(errors).to be_blank
                 end
               end
 
@@ -274,7 +272,7 @@ describe ParametersValidator do
                 end
 
                 it 'should call error_at with non-String prefix' do
-                  parameters_validator.should_receive(:error_at).with(
+                  expect(parameters_validator).to receive(:error_at).with(
                       hash_including(
                           :prefix => "has non-String parameter value (#{parameter_value.inspect})"
                       )
@@ -286,7 +284,7 @@ describe ParametersValidator do
                 it 'should record error' do
                   validate_each
 
-                  errors.should_not be_empty
+                  expect(errors).not_to be_empty
                 end
               end
             end
@@ -299,7 +297,7 @@ describe ParametersValidator do
           end
 
           it 'should use #error_at with has non-Array for prefix' do
-            parameters_validator.should_receive(:error_at).with(
+            expect(parameters_validator).to receive(:error_at).with(
                 hash_including(
                     :prefix => 'has non-Array'
                 )
@@ -311,7 +309,7 @@ describe ParametersValidator do
           it 'should record error' do
             validate_each
 
-            errors.should_not be_empty
+            expect(errors).not_to be_empty
           end
         end
       end
@@ -336,7 +334,7 @@ describe ParametersValidator do
 
       it 'should include TYPE_SIGNATURE_SENTENCE' do
         errors.each do |error|
-          error.should include(type_signature_sentence)
+          expect(error).to include(type_signature_sentence)
         end
       end
     end

--- a/spec/app/validators/password_is_strong_validator_spec.rb
+++ b/spec/app/validators/password_is_strong_validator_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe PasswordIsStrongValidator do
+RSpec.describe PasswordIsStrongValidator do
   subject(:password_is_strong_validator) do
     described_class.new(
         :attributes => attributes
@@ -99,7 +97,7 @@ describe PasswordIsStrongValidator do
         end
 
         it 'should escape username' do
-          Regexp.should_receive(:escape).with(username).and_call_original
+          expect(Regexp).to receive(:escape).with(username).and_call_original
 
           contains_username?
         end
@@ -167,7 +165,7 @@ describe PasswordIsStrongValidator do
       it 'should not record any error' do
         validate_each
 
-        record.errors.should be_empty
+        expect(record.errors).to be_empty
       end
     end
 
@@ -180,7 +178,7 @@ describe PasswordIsStrongValidator do
         it 'should record error on attributes' do
           validate_each
 
-          record.errors[attribute].should include('must contain letters, numbers, and at least one special character')
+          expect(record.errors[attribute]).to include('must contain letters, numbers, and at least one special character')
         end
       end
 
@@ -201,7 +199,7 @@ describe PasswordIsStrongValidator do
           it 'should record error on attribute' do
             validate_each
 
-            record.errors[attribute].should include('must not contain the username')
+            expect(record.errors[attribute]).to include('must not contain the username')
           end
         end
 
@@ -214,7 +212,7 @@ describe PasswordIsStrongValidator do
             it 'should record error on attribute' do
               validate_each
 
-              record.errors[attribute].should include('must not be a common password')
+              expect(record.errors[attribute]).to include('must not be a common password')
             end
           end
 
@@ -227,7 +225,7 @@ describe PasswordIsStrongValidator do
               it 'should record error on attribute' do
                 validate_each
 
-                record.errors[attribute].should include('must not be a predictable sequence of characters')
+                expect(record.errors[attribute]).to include('must not be a predictable sequence of characters')
               end
             end
 
@@ -239,7 +237,7 @@ describe PasswordIsStrongValidator do
               it 'should not record any errors' do
                 validate_each
 
-                record.errors.should be_empty
+                expect(record.errors).to be_empty
               end
             end
           end

--- a/spec/app/validators/password_is_strong_validator_spec.rb
+++ b/spec/app/validators/password_is_strong_validator_spec.rb
@@ -27,7 +27,7 @@ describe PasswordIsStrongValidator do
         'aaaaa'
       end
 
-      it { should be_true }
+      it { is_expected.to eq(true) }
     end
 
     context 'with repeats of 2 characters' do
@@ -35,7 +35,7 @@ describe PasswordIsStrongValidator do
         'abab'
       end
 
-      it { should be_true }
+      it { is_expected.to eq(true) }
     end
 
     context 'with repeats of 3 characters' do
@@ -43,7 +43,7 @@ describe PasswordIsStrongValidator do
         'abcabc'
       end
 
-      it { should be_true }
+      it { is_expected.to eq(true) }
     end
 
     context 'with repeats of 4 characters' do
@@ -51,7 +51,7 @@ describe PasswordIsStrongValidator do
         'abcdabcd'
       end
 
-      it { should be_true }
+      it { is_expected.to eq(true) }
     end
 
     context 'without any repeats' do
@@ -59,7 +59,7 @@ describe PasswordIsStrongValidator do
         'abcdefgh'
       end
 
-      it { should be_false }
+      it { is_expected.to eq(false) }
     end
   end
 
@@ -77,7 +77,7 @@ describe PasswordIsStrongValidator do
         ''
       end
 
-      it { should be_false }
+      it { is_expected.to eq(false) }
     end
 
     context 'without blank password' do
@@ -90,7 +90,7 @@ describe PasswordIsStrongValidator do
           ''
         end
 
-        it { should be_false }
+        it { is_expected.to eq(false) }
       end
 
       context 'without blank username' do
@@ -110,7 +110,7 @@ describe PasswordIsStrongValidator do
               username.titleize
             end
 
-            it { should be_true }
+            it { is_expected.to eq(true) }
           end
 
           context 'of same case' do
@@ -118,7 +118,7 @@ describe PasswordIsStrongValidator do
               username
             end
 
-            it { should be_true }
+            it { is_expected.to eq(true) }
           end
         end
       end

--- a/spec/lib/metasploit/model/association/error_spec.rb
+++ b/spec/lib/metasploit/model/association/error_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Association::Error do
+RSpec.describe Metasploit::Model::Association::Error do
   context '#initialize' do
     let(:attributes) do
       {

--- a/spec/lib/metasploit/model/association_spec.rb
+++ b/spec/lib/metasploit/model/association_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Association do
+RSpec.describe Metasploit::Model::Association do
   subject(:base_class) do
     described_class = self.described_class
 
@@ -54,7 +52,7 @@ describe Metasploit::Model::Association do
           end
 
           it 'should be class on which association was called' do
-            model.should == base_class
+            expect(model).to eq(base_class)
           end
         end
 
@@ -64,7 +62,7 @@ describe Metasploit::Model::Association do
           end
 
           it 'should be name passed to association as a Symbol' do
-            reflection_name.should == name.to_sym
+            expect(reflection_name).to eq(name.to_sym)
           end
         end
 
@@ -74,7 +72,7 @@ describe Metasploit::Model::Association do
           end
 
           it 'should be :class_name passed to association' do
-            reflection_class_name.should == class_name
+            expect(reflection_class_name).to eq(class_name)
           end
         end
       end
@@ -87,7 +85,7 @@ describe Metasploit::Model::Association do
     end
 
     it 'should default to empty Hash' do
-      association_by_name.should == {}
+      expect(association_by_name).to eq({})
     end
   end
 
@@ -119,7 +117,7 @@ describe Metasploit::Model::Association do
         end
 
         it 'should be class_name passed to association' do
-          reflection_class_name.should == class_name
+          expect(reflection_class_name).to eq(class_name)
         end
       end
 
@@ -129,7 +127,7 @@ describe Metasploit::Model::Association do
         end
 
         it 'should have the reflected name' do
-          reflection.name.should == reflected_name
+          expect(reflection.name).to eq(reflected_name)
         end
       end
     end
@@ -139,7 +137,7 @@ describe Metasploit::Model::Association do
         :unassociated_things
       end
 
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/lib/metasploit/model/base_spec.rb
+++ b/spec/lib/metasploit/model/base_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Base do
+RSpec.describe Metasploit::Model::Base do
   subject(:base_class) do
     Class.new(described_class)
   end
@@ -12,7 +10,7 @@ describe Metasploit::Model::Base do
     it 'should use public_send to set attributes' do
       attribute = :attribute
       value = double('Value')
-      base_class.any_instance.should_receive(:public_send).with("#{attribute}=", value)
+      expect_any_instance_of(base_class).to receive(:public_send).with("#{attribute}=", value)
 
       base_class.new(attribute => value)
     end
@@ -28,7 +26,7 @@ describe Metasploit::Model::Base do
     end
 
     before(:each) do
-      base_instance.stub(:valid? => valid)
+      allow(base_instance).to receive(:valid?).and_return(valid)
     end
 
     context 'with valid' do

--- a/spec/lib/metasploit/model/engine_spec.rb
+++ b/spec/lib/metasploit/model/engine_spec.rb
@@ -21,7 +21,13 @@ describe Metasploit::Model::Engine do
             options[:factory_girl]
           end
 
-          its([:dir]) { should == 'spec/factories' }
+          context 'dir' do
+            subject(:dir) {
+              factory_girl[:dir]
+            }
+
+            it { is_expected.to eq('spec/factories') }
+          end
         end
 
         context 'rails' do
@@ -29,10 +35,37 @@ describe Metasploit::Model::Engine do
             options[:rails]
           end
 
-          its([:assets]) { should be_false }
-          its([:fixture_replacement]) { should == :factory_girl }
-          its([:helper]) { should be_false }
-          its([:test_framework]) { should == :rspec }
+          context 'assets' do
+            subject(:assets) {
+              rails[:assets]
+            }
+
+            it { is_expected.to eq(false) }
+          end
+
+          context 'fixture_replacement' do
+            subject(:fixture_replacement) {
+              rails[:fixture_replacement]
+            }
+
+            it { is_expected.to eq(:factory_girl) }
+          end
+
+          context 'helper' do
+            subject(:helper) {
+              rails[:helper]
+            }
+
+            it { is_expected.to eq(false) }
+          end
+
+          context 'test_framework' do
+            subject(:test_framework) {
+              rails[:test_framework]
+            }
+
+            it { is_expected.to eq(:rspec) }
+          end
         end
 
         context 'rspec' do
@@ -40,7 +73,13 @@ describe Metasploit::Model::Engine do
             options[:rspec]
           end
 
-          its([:fixture]) { should be_false }
+          context 'fixture' do
+            subject(:fixture) {
+              rspec[:fixture]
+            }
+
+            it { is_expected.to eq(false) }
+          end
         end
       end
     end

--- a/spec/lib/metasploit/model/engine_spec.rb
+++ b/spec/lib/metasploit/model/engine_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Engine do
+RSpec.describe Metasploit::Model::Engine do
   context 'config' do
     subject(:config) do
       described_class.config
@@ -100,7 +98,7 @@ describe Metasploit::Model::Engine do
       end
 
       it 'should run after factory_girl.set_factory_paths' do
-        initializer.after.should == 'factory_girl.set_factory_paths'
+        expect(initializer.after).to eq('factory_girl.set_factory_paths')
       end
 
       context 'running' do
@@ -112,7 +110,7 @@ describe Metasploit::Model::Engine do
           it 'should prepend full path to spec/factories to FactoryGirl.definition_file_paths' do
             definition_file_path = Metasploit::Model::Engine.root.join('spec', 'factories')
 
-            FactoryGirl.definition_file_paths.should_receive(:unshift).with(definition_file_path)
+            expect(FactoryGirl.definition_file_paths).to receive(:unshift).with(definition_file_path)
 
             run
           end

--- a/spec/lib/metasploit/model/file_spec.rb
+++ b/spec/lib/metasploit/model/file_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::File do
+RSpec.describe Metasploit::Model::File do
   unless RUBY_PLATFORM =~ /java/ && Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('1.7.14')
     it 'aliases ::File' do
       expect(described_class).to equal(::File)
@@ -38,12 +36,12 @@ describe Metasploit::Model::File do
 
     if RUBY_PLATFORM =~ /java/ && Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('1.7.14')
       it 'should be necessary because File.realpath does not resolve symlinks' do
-        File.realpath(symlink_pathname.to_path).should_not == real_pathname.to_path
+        expect(File.realpath(symlink_pathname.to_path)).not_to eq(real_pathname.to_path)
       end
     end
 
     it 'should resolve symlink to real (canonical) path' do
-      realpath.should == real_pathname.to_path
+      expect(realpath).to eq(real_pathname.to_path)
     end
   end
 end

--- a/spec/lib/metasploit/model/invalid_spec.rb
+++ b/spec/lib/metasploit/model/invalid_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Invalid do
+RSpec.describe Metasploit::Model::Invalid do
   subject(:invalid) do
     described_class.new(model)
   end
@@ -18,13 +16,13 @@ describe Metasploit::Model::Invalid do
   it { should be_a Metasploit::Model::Error }
 
   it 'should use ActiveModel::Errors#full_messages' do
-    model.errors.should_receive(:full_messages).and_call_original
+    expect(model.errors).to receive(:full_messages).and_call_original
 
     described_class.new(model)
   end
 
   it 'should translate errors using metasploit.model.invalid' do
-    I18n.should_receive(:translate).with(
+    expect(I18n).to receive(:translate).with(
         'metasploit.model.errors.messages.model_invalid',
         hash_including(
             :errors => anything
@@ -36,10 +34,10 @@ describe Metasploit::Model::Invalid do
 
   it 'should set translated errors as message' do
     message = "translated message"
-    I18n.stub(:translate).with('metasploit.model.errors.messages.model_invalid', anything).and_return(message)
+    allow(I18n).to receive(:translate).with('metasploit.model.errors.messages.model_invalid', anything).and_return(message)
     instance = described_class.new(model)
 
-    instance.message.should == message
+    expect(instance.message).to eq(message)
   end
 
   context '#model' do
@@ -48,7 +46,7 @@ describe Metasploit::Model::Invalid do
     end
 
     it 'should be the passed in model' do
-      error_model.should == model
+      expect(error_model).to eq(model)
     end
   end
 end

--- a/spec/lib/metasploit/model/invalid_spec.rb
+++ b/spec/lib/metasploit/model/invalid_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Metasploit::Model::Invalid do
     end
   end
 
-  it { should be_a Metasploit::Model::Error }
+  it { is_expected.to be_a Metasploit::Model::Error }
 
   it 'should use ActiveModel::Errors#full_messages' do
     expect(model.errors).to receive(:full_messages).and_call_original

--- a/spec/lib/metasploit/model/login/status_spec.rb
+++ b/spec/lib/metasploit/model/login/status_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Login::Status do
+RSpec.describe Metasploit::Model::Login::Status do
   context 'CONSTANTS' do
     context 'ALL' do
       subject(:all) {

--- a/spec/lib/metasploit/model/nilify_blanks_spec.rb
+++ b/spec/lib/metasploit/model/nilify_blanks_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metasploit::Model::NilifyBlanks do
     it 'should support adding multiple attributes' do
       attributes = [:a, :b]
 
-      base_class.nilify_blank *attributes
+      base_class.nilify_blank(*attributes)
 
       attributes.each do |attribute|
         expect(base_class.nilify_blank_attribute_set).to include(attribute)

--- a/spec/lib/metasploit/model/nilify_blanks_spec.rb
+++ b/spec/lib/metasploit/model/nilify_blanks_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::NilifyBlanks do
+RSpec.describe Metasploit::Model::NilifyBlanks do
   let(:base_class) do
     # capture for class_eval scope
     described_class = self.described_class
@@ -24,7 +22,7 @@ describe Metasploit::Model::NilifyBlanks do
     end
 
     it 'should register #nilify_blanks as a before validation callback' do
-      base_class.should_receive(:before_validation).with(:nilify_blanks)
+      expect(base_class).to receive(:before_validation).with(:nilify_blanks)
 
       # capture for class_eval scope
       described_class = self.described_class
@@ -42,7 +40,7 @@ describe Metasploit::Model::NilifyBlanks do
       base_class.nilify_blank *attributes
 
       attributes.each do |attribute|
-        base_class.nilify_blank_attribute_set.should include(attribute)
+        expect(base_class.nilify_blank_attribute_set).to include(attribute)
       end
     end
 
@@ -52,7 +50,7 @@ describe Metasploit::Model::NilifyBlanks do
       base_class.nilify_blank attribute
       base_class.nilify_blank attribute
 
-      base_class.nilify_blank_attribute_set.length.should == 1
+      expect(base_class.nilify_blank_attribute_set.length).to eq(1)
     end
   end
 
@@ -90,14 +88,14 @@ describe Metasploit::Model::NilifyBlanks do
     end
 
     it 'should check if value responds to blank?' do
-      value.should_receive(:respond_to?).with(:blank?)
+      expect(value).to receive(:respond_to?).with(:blank?)
 
       nilify_blanks
     end
 
     context 'with value responds to blank?' do
       it 'should call blank?' do
-        value.should_receive(:blank?)
+        expect(value).to receive(:blank?)
 
         nilify_blanks
       end
@@ -110,7 +108,7 @@ describe Metasploit::Model::NilifyBlanks do
         it 'should set attribute to nil' do
           nilify_blanks
 
-          base_instance.blank.should be_nil
+          expect(base_instance.blank).to be_nil
         end
       end
 
@@ -133,11 +131,11 @@ describe Metasploit::Model::NilifyBlanks do
       end
 
       before(:each) do
-        value.stub(:respond_to?).with(:blank?).and_return(false)
+        allow(value).to receive(:respond_to?).with(:blank?).and_return(false)
       end
 
       it 'should not call blank?' do
-        value.should_not_receive(:blank?)
+        expect(value).not_to receive(:blank?)
 
         nilify_blanks
       end
@@ -150,7 +148,7 @@ describe Metasploit::Model::NilifyBlanks do
     end
 
     it 'should default to an empty Set' do
-      nilify_blank_attribute_set.should == Set.new
+      expect(nilify_blank_attribute_set).to eq(Set.new)
     end
   end
 end

--- a/spec/lib/metasploit/model/realm/key_spec.rb
+++ b/spec/lib/metasploit/model/realm/key_spec.rb
@@ -1,13 +1,11 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Realm::Key do
+RSpec.describe Metasploit::Model::Realm::Key do
   context 'CONSTANTS' do
     context 'ACTIVE_DIRECTORY_DOMAIN' do
       subject(:active_directory_domain) do
         described_class::ACTIVE_DIRECTORY_DOMAIN
       end
 
-      it { should == 'Active Directory Domain' }
+      it { is_expected.to eq('Active Directory Domain') }
       it { should be_in described_class::ALL }
     end
 
@@ -27,7 +25,7 @@ describe Metasploit::Model::Realm::Key do
         described_class::ORACLE_SYSTEM_IDENTIFIER
       end
 
-      it { should == 'Oracle System Identifier' }
+      it { is_expected.to eq('Oracle System Identifier') }
       it { should be_in described_class::ALL }
     end
 
@@ -36,7 +34,7 @@ describe Metasploit::Model::Realm::Key do
         described_class::POSTGRESQL_DATABASE
       end
 
-      it { should == 'PostgreSQL Database' }
+      it { is_expected.to eq('PostgreSQL Database') }
       it { should be_in described_class::ALL }
     end
 
@@ -45,7 +43,7 @@ describe Metasploit::Model::Realm::Key do
         described_class::WILDCARD
       end
 
-      it { should == '*' }
+      it { is_expected.to eq('*') }
       it { should be_in described_class::ALL }
     end
 
@@ -53,7 +51,7 @@ describe Metasploit::Model::Realm::Key do
       subject { described_class::SHORT_NAMES }
       it 'should have String keys' do
         subject.keys.each { |key|
-          key.should be_a(String)
+          expect(key).to be_a(String)
         }
       end
       context 'values' do

--- a/spec/lib/metasploit/model/realm/key_spec.rb
+++ b/spec/lib/metasploit/model/realm/key_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Metasploit::Model::Realm::Key do
       end
 
       it { is_expected.to eq('Active Directory Domain') }
-      it { should be_in described_class::ALL }
+      it { is_expected.to be_in described_class::ALL }
     end
 
     context 'ALL' do
@@ -14,10 +14,10 @@ RSpec.describe Metasploit::Model::Realm::Key do
         described_class::ALL
       end
 
-      it { should include described_class::ACTIVE_DIRECTORY_DOMAIN }
-      it { should include described_class::ORACLE_SYSTEM_IDENTIFIER }
-      it { should include described_class::POSTGRESQL_DATABASE }
-      it { should include described_class::WILDCARD }
+      it { is_expected.to include described_class::ACTIVE_DIRECTORY_DOMAIN }
+      it { is_expected.to include described_class::ORACLE_SYSTEM_IDENTIFIER }
+      it { is_expected.to include described_class::POSTGRESQL_DATABASE }
+      it { is_expected.to include described_class::WILDCARD }
     end
 
     context 'ORACLE_SYSTEM_IDENTIFIER' do
@@ -26,7 +26,7 @@ RSpec.describe Metasploit::Model::Realm::Key do
       end
 
       it { is_expected.to eq('Oracle System Identifier') }
-      it { should be_in described_class::ALL }
+      it { is_expected.to be_in described_class::ALL }
     end
 
     context 'POSTGRESQL DATABASE' do
@@ -35,7 +35,7 @@ RSpec.describe Metasploit::Model::Realm::Key do
       end
 
       it { is_expected.to eq('PostgreSQL Database') }
-      it { should be_in described_class::ALL }
+      it { is_expected.to be_in described_class::ALL }
     end
 
     context 'WILDCARD' do
@@ -44,7 +44,7 @@ RSpec.describe Metasploit::Model::Realm::Key do
       end
 
       it { is_expected.to eq('*') }
-      it { should be_in described_class::ALL }
+      it { is_expected.to be_in described_class::ALL }
     end
 
     context 'SHORT_NAMES' do
@@ -56,7 +56,7 @@ RSpec.describe Metasploit::Model::Realm::Key do
       end
       context 'values' do
         subject { described_class::SHORT_NAMES.values.sort }
-        it { should match_array(described_class::ALL.sort) }
+        it { is_expected.to match_array(described_class::ALL.sort) }
       end
     end
   end

--- a/spec/lib/metasploit/model/search/association/tree_spec.rb
+++ b/spec/lib/metasploit/model/search/association/tree_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Metasploit::Model::Association::Tree do
               nil
             }
 
-            it { should be_nil }
+            it { is_expected.to be_nil }
           end
 
           context 'without nil' do

--- a/spec/lib/metasploit/model/search/association/tree_spec.rb
+++ b/spec/lib/metasploit/model/search/association/tree_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Association::Tree do
+RSpec.describe Metasploit::Model::Association::Tree do
   context 'expand' do
     subject(:expand) {
       described_class.expand(associations)
@@ -311,7 +309,7 @@ describe Metasploit::Model::Association::Tree do
         nil
       }
 
-      it { should == [] }
+      it { is_expected.to eq([]) }
     end
   end
 

--- a/spec/lib/metasploit/model/search/association_spec.rb
+++ b/spec/lib/metasploit/model/search/association_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Metasploit::Model::Search::Association do
 
   context 'search_associations' do
     subject(:search_associations) {
-      base_class.search_associations *associations
+      base_class.search_associations(*associations)
     }
 
     let(:associations) {

--- a/spec/lib/metasploit/model/search/association_spec.rb
+++ b/spec/lib/metasploit/model/search/association_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Association do
+RSpec.describe Metasploit::Model::Search::Association do
   subject(:base_class) do
     described_class = self.described_class
 

--- a/spec/lib/metasploit/model/search/attribute_spec.rb
+++ b/spec/lib/metasploit/model/search/attribute_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Attribute do
+RSpec.describe Metasploit::Model::Search::Attribute do
   subject(:base_class) do
     described_class = self.described_class
 
@@ -26,7 +24,7 @@ describe Metasploit::Model::Search::Attribute do
           end
 
           it 'should call search_with' do
-            base_class.should_receive(:search_with).with(
+            expect(base_class).to receive(:search_with).with(
                 Metasploit::Model::Search::Operator::Attribute,
                 hash_including(
                     :attribute => attribute,
@@ -40,7 +38,7 @@ describe Metasploit::Model::Search::Attribute do
           it 'should be in search_attribute_operator_by_attribute' do
             # grab operator first since it calls search_attribute and populates search_attribute_operator_by_attribute
             cached = operator
-            base_class.search_with_operator_by_name[attribute].should == cached
+            expect(base_class.search_with_operator_by_name[attribute]).to eq(cached)
           end
 
           context 'attribute' do
@@ -49,7 +47,7 @@ describe Metasploit::Model::Search::Attribute do
             end
 
             it 'should be the attribute passed to search_attribute' do
-              operator_attribute.should == attribute
+              expect(operator_attribute).to eq(attribute)
             end
           end
 
@@ -59,7 +57,7 @@ describe Metasploit::Model::Search::Attribute do
             end
 
             it 'should be class on which search_attribute was called' do
-              klass.should == base_class
+              expect(klass).to eq(base_class)
             end
           end
 
@@ -69,7 +67,7 @@ describe Metasploit::Model::Search::Attribute do
             end
 
             it 'should be type passed to search_attribute' do
-              operator_type.should == type
+              expect(operator_type).to eq(type)
             end
           end
         end

--- a/spec/lib/metasploit/model/search/operation/value/integer_spec.rb
+++ b/spec/lib/metasploit/model/search/operation/value/integer_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Value::Integer do
+RSpec.describe Metasploit::Model::Search::Operation::Value::Integer do
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::Integer' do
     let(:operation_class) do
       described_class = self.described_class

--- a/spec/lib/metasploit/model/search/operation/value/string_spec.rb
+++ b/spec/lib/metasploit/model/search/operation/value/string_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation::Value::String do
+RSpec.describe Metasploit::Model::Search::Operation::Value::String do
   it_should_behave_like 'Metasploit::Model::Search::Operation::Value::String' do
     let(:operation_class) do
       described_class = self.described_class

--- a/spec/lib/metasploit/model/search/operation_spec.rb
+++ b/spec/lib/metasploit/model/search/operation_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operation do
+RSpec.describe Metasploit::Model::Search::Operation do
   context 'parse' do
     subject(:parse) do
       described_class.parse(options)
@@ -48,8 +46,8 @@ describe Metasploit::Model::Search::Operation do
 
         context "with at least one ':' in :formatted_operation" do
           before(:each) do
-            query.stub(:parse_operator).with(formatted_operator).and_return(operator)
-            operator.stub(:operate_on).with(formatted_value).and_return(operation)
+            allow(query).to receive(:parse_operator).with(formatted_operator).and_return(operator)
+            allow(operator).to receive(:operate_on).with(formatted_value).and_return(operation)
           end
 
           context "with multiple ':' in :formatted_operation" do
@@ -58,13 +56,13 @@ describe Metasploit::Model::Search::Operation do
             end
 
             it "should treat portion before first ':' as formatted operator" do
-              query.should_receive(:parse_operator).with(formatted_operator)
+              expect(query).to receive(:parse_operator).with(formatted_operator)
 
               parse
             end
 
             it "should treat portion after first ':' as formatted value including later ':'" do
-              operator.should_receive(:operate_on).with(formatted_value)
+              expect(operator).to receive(:operate_on).with(formatted_value)
 
               parse
             end
@@ -76,13 +74,13 @@ describe Metasploit::Model::Search::Operation do
             end
 
             it "should use portion before ':' as formatted operator" do
-              query.should_receive(:parse_operator).with(formatted_operator)
+              expect(query).to receive(:parse_operator).with(formatted_operator)
 
               parse
             end
 
             it "should use portion after ':' as formatted value" do
-              operator.should_receive(:operate_on).with(formatted_value)
+              expect(operator).to receive(:operate_on).with(formatted_value)
 
               parse
             end
@@ -103,17 +101,17 @@ describe Metasploit::Model::Search::Operation do
           end
 
           it "should use entirety as formatted operator" do
-            operator.stub(:operate_on).and_return(operation)
+            allow(operator).to receive(:operate_on).and_return(operation)
 
-            query.should_receive(:parse_operator).with(formatted_operator).and_return(operator)
+            expect(query).to receive(:parse_operator).with(formatted_operator).and_return(operator)
 
             parse
           end
 
           it "should use '' as formatted value instead of nil" do
-            query.stub(:parse_operator).and_return(operator)
+            allow(query).to receive(:parse_operator).and_return(operator)
 
-            operator.should_receive(:operate_on).with('')
+            expect(operator).to receive(:operate_on).with('')
 
             parse
           end

--- a/spec/lib/metasploit/model/search/operator/help_spec.rb
+++ b/spec/lib/metasploit/model/search/operator/help_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::Operator::Help do
+RSpec.describe Metasploit::Model::Search::Operator::Help do
   it_should_behave_like 'Metasploit::Model::Search::Operator::Help' do
     let(:operator) do
       operator_class.new(

--- a/spec/lib/metasploit/model/search/with_spec.rb
+++ b/spec/lib/metasploit/model/search/with_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search::With do
+RSpec.describe Metasploit::Model::Search::With do
   let(:base_class) do
     described_class = self.described_class
 
@@ -37,7 +35,7 @@ describe Metasploit::Model::Search::With do
     end
 
     it 'should pass given options to operator_class.new' do
-      operator_class.should_receive(:new).with(
+      expect(operator_class).to receive(:new).with(
           hash_including(options)
       ).and_return(operator)
 
@@ -45,7 +43,7 @@ describe Metasploit::Model::Search::With do
     end
 
     it 'should merge :klass into options passed to operator.new' do
-      operator_class.should_receive(:new).with(
+      expect(operator_class).to receive(:new).with(
           hash_including(
               :klass => base_class
           )
@@ -55,9 +53,9 @@ describe Metasploit::Model::Search::With do
     end
 
     it 'should validate operator' do
-      operator_class.stub(:new).and_return(operator)
+      allow(operator_class).to receive(:new).and_return(operator)
 
-      operator.should_receive(:valid!)
+      expect(operator).to receive(:valid!)
 
       search_with_operator
     end
@@ -65,7 +63,7 @@ describe Metasploit::Model::Search::With do
     it 'should add operator to search_with_operator_by_name' do
       search_with_operator
 
-      base_class.search_with_operator_by_name[operator.name].should == operator
+      expect(base_class.search_with_operator_by_name[operator.name]).to eq(operator)
     end
   end
 
@@ -75,7 +73,7 @@ describe Metasploit::Model::Search::With do
     end
 
     it 'should default to empty Hash' do
-      search_with_operator_by_name.should == {}
+      expect(search_with_operator_by_name).to eq({})
     end
   end
 end

--- a/spec/lib/metasploit/model/search_spec.rb
+++ b/spec/lib/metasploit/model/search_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Search do
+RSpec.describe Metasploit::Model::Search do
   subject(:base_instance) do
     base_class.new
   end
@@ -45,7 +43,7 @@ describe Metasploit::Model::Search do
           end
 
           it 'should be same as the attribute' do
-            name.should == attribute
+            expect(name).to eq(attribute)
           end
         end
       end
@@ -98,7 +96,7 @@ describe Metasploit::Model::Search do
           end
 
           it 'should be the registered association' do
-            operator_association.should == association
+            expect(operator_association).to eq(association)
           end
         end
 
@@ -112,7 +110,7 @@ describe Metasploit::Model::Search do
           end
 
           it 'should be operator from associated class' do
-            source_operator.should == direct_attribute_operator
+            expect(source_operator).to eq(direct_attribute_operator)
           end
         end
 
@@ -122,7 +120,7 @@ describe Metasploit::Model::Search do
           end
 
           it 'should be class that called search_operator_by_name' do
-            klass.should == base_class
+            expect(klass).to eq(base_class)
           end
         end
       end
@@ -155,7 +153,7 @@ describe Metasploit::Model::Search do
         end
 
         it 'should be in search_operator_by_name' do
-          named_operator.should == operator
+          expect(named_operator).to eq(operator)
         end
       end
     end

--- a/spec/lib/metasploit/model/search_spec.rb
+++ b/spec/lib/metasploit/model/search_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Metasploit::Model::Search do
     base_class.send(:include, described_class)
   end
 
-  it { should be_a Metasploit::Model::Search::Association }
-  it { should be_a Metasploit::Model::Search::Attribute }
-  it { should be_a Metasploit::Model::Search::With }
+  it { is_expected.to be_a Metasploit::Model::Search::Association }
+  it { is_expected.to be_a Metasploit::Model::Search::Attribute }
+  it { is_expected.to be_a Metasploit::Model::Search::With }
 
   context 'search_operator_by_name' do
     subject(:search_operator_by_name) do
@@ -88,7 +88,7 @@ RSpec.describe Metasploit::Model::Search do
           "#{association}.#{associated_attribute}".to_sym
         end
 
-        it { should be_a Metasploit::Model::Search::Operator::Association }
+        it { is_expected.to be_a Metasploit::Model::Search::Operator::Association }
 
         context 'association' do
           subject(:operator_association) do
@@ -161,7 +161,7 @@ RSpec.describe Metasploit::Model::Search do
     context 'without search attribute' do
       context 'without search association' do
         context 'without search with' do
-          it { should be_empty }
+          it { is_expected.to be_empty }
         end
       end
     end

--- a/spec/lib/metasploit/model/spec/error_spec.rb
+++ b/spec/lib/metasploit/model/spec/error_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Spec::Error do
+RSpec.describe Metasploit::Model::Spec::Error do
   it { should be_a StandardError }
 end

--- a/spec/lib/metasploit/model/spec/error_spec.rb
+++ b/spec/lib/metasploit/model/spec/error_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe Metasploit::Model::Spec::Error do
-  it { should be_a StandardError }
+  it { is_expected.to be_a StandardError }
 end

--- a/spec/lib/metasploit/model/spec/i18n_exception_handler_spec.rb
+++ b/spec/lib/metasploit/model/spec/i18n_exception_handler_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Metasploit::Model::Spec::I18nExceptionHandler do
       expect {
         call
       }.to raise_error(converted_exception.class) do |actual_exception|
-        actual_exception.class == converted_exception.class
+        expect(actual_exception.class).to eq(converted_exception.class)
         expect(actual_exception.key).to eq(converted_exception.key)
         expect(actual_exception.locale).to eq(converted_exception.locale)
         expect(actual_exception.options).to eq(converted_exception.options)

--- a/spec/lib/metasploit/model/spec/i18n_exception_handler_spec.rb
+++ b/spec/lib/metasploit/model/spec/i18n_exception_handler_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Spec::I18nExceptionHandler do
+RSpec.describe Metasploit::Model::Spec::I18nExceptionHandler do
   subject(:i18n_exception_handler) do
     described_class.new
   end
@@ -33,9 +31,9 @@ describe Metasploit::Model::Spec::I18nExceptionHandler do
         call
       }.to raise_error(converted_exception.class) do |actual_exception|
         actual_exception.class == converted_exception.class
-        actual_exception.key.should == converted_exception.key
-        actual_exception.locale.should == converted_exception.locale
-        actual_exception.options.should == converted_exception.options
+        expect(actual_exception.key).to eq(converted_exception.key)
+        expect(actual_exception.locale).to eq(converted_exception.locale)
+        expect(actual_exception.options).to eq(converted_exception.options)
       end
     end
   end

--- a/spec/lib/metasploit/model/spec/pathname_collision_spec.rb
+++ b/spec/lib/metasploit/model/spec/pathname_collision_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Metasploit::Model::Spec::PathnameCollision do
     described_class.new(pathname)
   end
 
-  it { should be_a Metasploit::Model::Spec::Error }
+  it { is_expected.to be_a Metasploit::Model::Spec::Error }
 
   context 'check!' do
     subject(:check!) do

--- a/spec/lib/metasploit/model/spec/pathname_collision_spec.rb
+++ b/spec/lib/metasploit/model/spec/pathname_collision_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Spec::PathnameCollision do
+RSpec.describe Metasploit::Model::Spec::PathnameCollision do
   let(:pathname) do
     Metasploit::Model::Spec.temporary_pathname.join('pathname')
   end
@@ -44,11 +42,11 @@ describe Metasploit::Model::Spec::PathnameCollision do
       end
 
       it 'should include pathname' do
-        message.should include("#{pathname} already exists.")
+        expect(message).to include("#{pathname} already exists.")
       end
 
       it 'should include potential cause' do
-        message.should include('Metasploit::Model::Spec.remove_temporary_pathname was not called after the previous spec.')
+        expect(message).to include('Metasploit::Model::Spec.remove_temporary_pathname was not called after the previous spec.')
       end
     end
   end

--- a/spec/lib/metasploit/model/spec_spec.rb
+++ b/spec/lib/metasploit/model/spec_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Spec do
+RSpec.describe Metasploit::Model::Spec do
   before(:each) do
     @before_temporary_pathname = described_class.send(:remove_instance_variable, :@temporary_pathname)
   end
@@ -82,7 +80,7 @@ describe Metasploit::Model::Spec do
       end
 
       it 'should return set pathname' do
-        temporary_pathname.should == pathname
+        expect(temporary_pathname).to eq(pathname)
       end
     end
 

--- a/spec/lib/metasploit/model/spec_spec.rb
+++ b/spec/lib/metasploit/model/spec_spec.rb
@@ -105,7 +105,11 @@ RSpec.describe Metasploit::Model::Spec do
       expect {
         described_class.temporary_pathname = temporary_pathname
       }.to change {
-        described_class.instance_variable_get(:@temporary_pathname)
+                   if described_class.instance_variable_defined? :@temporary_pathname
+                     described_class.instance_variable_get(:@temporary_pathname)
+                   else
+                     nil
+                   end
       }.to(temporary_pathname)
     end
   end

--- a/spec/lib/metasploit/model/spec_spec.rb
+++ b/spec/lib/metasploit/model/spec_spec.rb
@@ -35,11 +35,11 @@ describe Metasploit::Model::Spec do
         end
 
         it 'should remove file tree' do
-          pathname.exist?.should be_true
+          expect(pathname.exist?).to eq(true)
 
           remove_temporary_pathname
 
-          pathname.exist?.should be_false
+          expect(pathname.exist?).to eq(false)
         end
       end
 

--- a/spec/lib/metasploit/model/translation_spec.rb
+++ b/spec/lib/metasploit/model/translation_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Translation do
+RSpec.describe Metasploit::Model::Translation do
   let(:base_class) do
     described_class = self.described_class
 
@@ -56,21 +54,21 @@ describe Metasploit::Model::Translation do
     end
 
     it 'should have named and unnamed ancestors' do
-      base_class.ancestors.should include(named_class)
-      base_class.ancestors.should include(named_module)
-      base_class.ancestors.should include(unnamed_class)
-      base_class.ancestors.should include(unnamed_module)
+      expect(base_class.ancestors).to include(named_class)
+      expect(base_class.ancestors).to include(named_module)
+      expect(base_class.ancestors).to include(unnamed_class)
+      expect(base_class.ancestors).to include(unnamed_module)
     end
 
     it 'should return all ancestors that respond to model_name' do
-      lookup_ancestors.should include(base_class)
-      lookup_ancestors.should include(named_class)
-      lookup_ancestors.should include(named_module)
+      expect(lookup_ancestors).to include(base_class)
+      expect(lookup_ancestors).to include(named_class)
+      expect(lookup_ancestors).to include(named_module)
     end
 
     it 'should not return ancestors that do not respond to model_name' do
-      lookup_ancestors.should_not include(unnamed_class)
-      lookup_ancestors.should_not include(unnamed_module)
+      expect(lookup_ancestors).not_to include(unnamed_class)
+      expect(lookup_ancestors).not_to include(unnamed_module)
     end
   end
 

--- a/spec/lib/metasploit/model/version_spec.rb
+++ b/spec/lib/metasploit/model/version_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Version do
+RSpec.describe Metasploit::Model::Version do
   context 'CONSTANTS' do
     context 'MAJOR' do
       subject(:major) do

--- a/spec/lib/metasploit/model/version_spec.rb
+++ b/spec/lib/metasploit/model/version_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Metasploit::Model::Version do
         described_class::MINOR
       end
 
-      it { should be_a Integer }
+      it { is_expected.to be_a Integer }
     end
 
     context 'PATCH' do
@@ -23,7 +23,7 @@ RSpec.describe Metasploit::Model::Version do
         described_class::PATCH
       end
 
-      it { should be_a Integer }
+      it { is_expected.to be_a Integer }
     end
 
     pull_request = ENV['TRAVIS_PULL_REQUEST']

--- a/spec/lib/metasploit/model/visitation/visit_spec.rb
+++ b/spec/lib/metasploit/model/visitation/visit_spec.rb
@@ -91,15 +91,19 @@ describe Metasploit::Model::Visitation::Visit do
           visit.should be_an Array
           visit.length.should == module_names.length
 
-          visit.all? { |visitor|
-            visitor.is_a? Metasploit::Model::Visitation::Visitor
-          }.should be_true
+          expect(
+              visit.all? { |visitor|
+                visitor.is_a? Metasploit::Model::Visitation::Visitor
+              }
+          ).to eq(true)
         end
 
         it 'should each Metasploit::Model::Visitation::Visitor to visitor_by_module_name' do
-          module_names.all? { |module_name|
-            visit.include? base_class.visitor_by_module_name[module_name]
-          }.should be_true
+          expect(
+              module_names.all? { |module_name|
+                visit.include? base_class.visitor_by_module_name[module_name]
+              }
+          ).to eq(true)
         end
       end
     end

--- a/spec/lib/metasploit/model/visitation/visit_spec.rb
+++ b/spec/lib/metasploit/model/visitation/visit_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe Metasploit::Model::Visitation::Visit do
+RSpec.describe Metasploit::Model::Visitation::Visit do
   let(:base_class) do
     described_class = self.described_class
 
@@ -54,15 +52,15 @@ describe Metasploit::Model::Visitation::Visit do
         end
 
         it 'should return Array(Metasploit::Model::Visitation::Visitor)' do
-          visit.should be_an Array
-          visit.length.should == 1
-          visit.first.should be_a Metasploit::Model::Visitation::Visitor
+          expect(visit).to be_an Array
+          expect(visit.length).to eq(1)
+          expect(visit.first).to be_a Metasploit::Model::Visitation::Visitor
         end
 
         it 'should add Metasploit::Model::Visitation::Visitor to visitor_by_module_name' do
           visitor = visit.first
 
-          base_class.visitor_by_module_name[mod.name].should == visitor
+          expect(base_class.visitor_by_module_name[mod.name]).to eq(visitor)
         end
       end
 
@@ -88,8 +86,8 @@ describe Metasploit::Model::Visitation::Visit do
         end
 
         it 'should return Array<Metasploit::Model::Visitation::Visitor>' do
-          visit.should be_an Array
-          visit.length.should == module_names.length
+          expect(visit).to be_an Array
+          expect(visit.length).to eq(module_names.length)
 
           expect(
               visit.all? { |visitor|
@@ -162,7 +160,7 @@ describe Metasploit::Model::Visitation::Visit do
       end
 
       it 'should return visitor from visitor_by_module' do
-        visitor.should == klass_visitor
+        expect(visitor).to eq(klass_visitor)
       end
     end
 
@@ -191,13 +189,13 @@ describe Metasploit::Model::Visitation::Visit do
         end
 
         it 'should return ancestor visitor' do
-          visitor.should == ancestor_visitor
+          expect(visitor).to eq(ancestor_visitor)
         end
 
         it 'should cache ancestor visitor as visitor for klass in visitor_by_module' do
           visitor
 
-          base_class.visitor_by_module[klass].should == ancestor_visitor
+          expect(base_class.visitor_by_module[klass]).to eq(ancestor_visitor)
         end
       end
 
@@ -207,13 +205,13 @@ describe Metasploit::Model::Visitation::Visit do
         end
 
         it 'should return ancestor visitor' do
-          visitor.should == ancestor_visitor
+          expect(visitor).to eq(ancestor_visitor)
         end
 
         it 'should cache ancestor visitor as visitor for klass in visitor_by_module' do
           visitor
 
-          base_class.visitor_by_module[klass].should == ancestor_visitor
+          expect(base_class.visitor_by_module[klass]).to eq(ancestor_visitor)
         end
       end
 
@@ -233,7 +231,7 @@ describe Metasploit::Model::Visitation::Visit do
     end
 
     it 'should default to empty Hash' do
-      visitor_by_module.should == {}
+      expect(visitor_by_module).to eq({})
     end
   end
 
@@ -243,7 +241,7 @@ describe Metasploit::Model::Visitation::Visit do
     end
 
     it 'should default to empty Hash' do
-      visitor_by_module_name.should == {}
+      expect(visitor_by_module_name).to eq({})
     end
   end
 
@@ -278,13 +276,13 @@ describe Metasploit::Model::Visitation::Visit do
     end
 
     it 'should find visitor for node.class' do
-      base_class.should_receive(:visitor).with(node.class).and_call_original
+      expect(base_class).to receive(:visitor).with(node.class).and_call_original
 
       visit
     end
 
     it 'should visit on visitor' do
-      @visitor.should_receive(:visit).with(base_instance, node)
+      expect(@visitor).to receive(:visit).with(base_instance, node)
 
       visit
     end
@@ -313,7 +311,7 @@ describe Metasploit::Model::Visitation::Visit do
       end
 
       it "should be able to call visit from inside a visitor's block" do
-        visit.should == leaf_node
+        expect(visit).to eq(leaf_node)
       end
     end
   end

--- a/spec/matchers/validate_nilness_of_spec.rb
+++ b/spec/matchers/validate_nilness_of_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'validate_nilness_of' do
   let(:record) {
     record_class.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,6 @@ SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
-
 
 spec_pathname = Metasploit::Model::Engine.root.join('spec')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,6 @@ require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 
-# full backtrace in logs so its easier to trace errors
-Rails.backtrace_cleaner.remove_silencers!
 
 spec_pathname = Metasploit::Model::Engine.root.join('spec')
 
@@ -25,7 +23,76 @@ Dir[spec_pathname.join('support', '**', '*.rb')].each do |f|
   require f
 end
 
+# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # These two settings work together to allow you to limit a spec run
+  # to individual examples or groups you care about by tagging them with
+  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  # get run.
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
+  #   - http://teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
+  config.disable_monkey_patching!
+
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  config.warnings = true
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+
   config.before(:suite) do
     # this must be explicitly set here because it should always be spec/tmp for w/e project is using
     # Metasploit::Model::Spec to handle file system clean up.
@@ -40,7 +107,4 @@ RSpec.configure do |config|
   config.after(:each) do
     Metasploit::Model::Spec.remove_temporary_pathname
   end
-
-  config.mock_with :rspec
-  config.order = :random
 end

--- a/spec/support/shared/contexts/metasploit/model/search/operator/union/children.rb
+++ b/spec/support/shared/contexts/metasploit/model/search/operator/union/children.rb
@@ -1,4 +1,4 @@
-shared_context 'Metasploit::Model::Search::Operator::Group::Union#children' do
+RSpec.shared_context 'Metasploit::Model::Search::Operator::Group::Union#children' do
   subject(:children) do
     operator.children(formatted_value)
   end

--- a/spec/support/shared/examples/metasploit/model/search/operation/value/integer.rb
+++ b/spec/support/shared/examples/metasploit/model/search/operation/value/integer.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples_for 'Metasploit::Model::Search::Operation::Value::Integer'
       operation_class
     end
 
-    it { should include Metasploit::Model::Search::Operation::Value::Integer }
+    it { is_expected.to include Metasploit::Model::Search::Operation::Value::Integer }
   end
 
   context '#value' do

--- a/spec/support/shared/examples/metasploit/model/search/operation/value/integer.rb
+++ b/spec/support/shared/examples/metasploit/model/search/operation/value/integer.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Model::Search::Operation::Value::Integer' do
+RSpec.shared_examples_for 'Metasploit::Model::Search::Operation::Value::Integer' do
   let(:operation_class) do
     described_class
   end
@@ -26,7 +26,7 @@ shared_examples_for 'Metasploit::Model::Search::Operation::Value::Integer' do
       end
 
       it 'should pass through Integer' do
-        value.should == formatted_value
+        expect(value).to eq(formatted_value)
       end
     end
 
@@ -40,7 +40,7 @@ shared_examples_for 'Metasploit::Model::Search::Operation::Value::Integer' do
       end
 
       it 'should convert String to Integer' do
-        value.should == integer
+        expect(value).to eq(integer)
       end
     end
 
@@ -54,11 +54,11 @@ shared_examples_for 'Metasploit::Model::Search::Operation::Value::Integer' do
       end
 
       it 'should not extract the number' do
-        value.should_not == integer
+        expect(value).not_to eq(integer)
       end
 
       it 'should pass through the full value' do
-        value.should == formatted_value
+        expect(value).to eq(formatted_value)
       end
     end
 
@@ -68,11 +68,11 @@ shared_examples_for 'Metasploit::Model::Search::Operation::Value::Integer' do
       end
 
       it 'should not truncate Float to Integer' do
-        value.should_not == formatted_value.to_i
+        expect(value).not_to eq(formatted_value.to_i)
       end
 
       it 'should pass through Float' do
-        value.should == formatted_value
+        expect(value).to eq(formatted_value)
       end
     end
   end

--- a/spec/support/shared/examples/metasploit/model/search/operation/value/string.rb
+++ b/spec/support/shared/examples/metasploit/model/search/operation/value/string.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Model::Search::Operation::Value::String' do
+RSpec.shared_examples_for 'Metasploit::Model::Search::Operation::Value::String' do
   let(:operation_class) do
     described_class
   end
@@ -26,7 +26,7 @@ shared_examples_for 'Metasploit::Model::Search::Operation::Value::String' do
       end
 
       it 'should convert to String' do
-        value.should == '5'
+        expect(value).to eq('5')
       end
     end
 
@@ -36,7 +36,7 @@ shared_examples_for 'Metasploit::Model::Search::Operation::Value::String' do
       end
 
       it 'should pass through String' do
-        value.should == formatted_value
+        expect(value).to eq(formatted_value)
       end
     end
 
@@ -46,7 +46,7 @@ shared_examples_for 'Metasploit::Model::Search::Operation::Value::String' do
       end
 
       it 'should convert to String' do
-        value.should == 'a_symbol'
+        expect(value).to eq('a_symbol')
       end
     end
   end

--- a/spec/support/shared/examples/metasploit/model/search/operation/value/string.rb
+++ b/spec/support/shared/examples/metasploit/model/search/operation/value/string.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples_for 'Metasploit::Model::Search::Operation::Value::String' 
       operation_class
     end
 
-    it { should include Metasploit::Model::Search::Operation::Value::String }
+    it { is_expected.to include Metasploit::Model::Search::Operation::Value::String }
   end
 
   context '#value' do

--- a/spec/support/shared/examples/metasploit/model/search/operator/help.rb
+++ b/spec/support/shared/examples/metasploit/model/search/operator/help.rb
@@ -99,9 +99,11 @@ shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
 
         default.should be_an Array
 
-        default.all? { |key|
-          key.is_a? Symbol
-        }.should be_true
+        expect(
+            default.all? { |key|
+              key.is_a? Symbol
+            }
+        ).to eq(true)
       end
 
       help

--- a/spec/support/shared/examples/metasploit/model/search/operator/help.rb
+++ b/spec/support/shared/examples/metasploit/model/search/operator/help.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
+RSpec.shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
   context '#help' do
     subject(:help) do
       operator.help
@@ -24,7 +24,7 @@ shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
       # klass needs to be named or model_name will fail.
       stub_const('Klass', klass)
       # since missing translations raise exceptions, and there is no translation for klass, have to stub out.
-      klass.model_name.stub(:human).and_return(model)
+      allow(klass.model_name).to receive(:human).and_return(model)
 
       backend = I18n.backend
 
@@ -59,31 +59,31 @@ shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
     end
 
     it 'should use #klass #i18n_scope to lookup translations specific to the #klass or one of its ancestors' do
-      klass.should_receive(:i18n_scope).and_call_original
+      expect(klass).to receive(:i18n_scope).and_call_original
 
       help
     end
 
     it 'should lookup ancestors of #klass to find translations specific to #klass or its ancestors' do
-      klass.should_receive(:lookup_ancestors).and_call_original
+      expect(klass).to receive(:lookup_ancestors).and_call_original
 
       help
     end
 
     it 'should use #class #i18n_scope to lookup translations specific to the operator class or one of its ancestors' do
-      operator.class.should_receive(:i18n_scope)
+      expect(operator.class).to receive(:i18n_scope)
 
       help
     end
 
     it 'should lookup ancestors of the operator class to find translations specific to the operator class or one of its ancestors' do
-      operator.class.should_receive(:lookup_ancestors).and_return([])
+      expect(operator.class).to receive(:lookup_ancestors).and_return([])
 
       help
     end
 
     it "should pass #klass translation key for operator with the given name as the primary translation key" do
-      I18n.should_receive(:translate).with(
+      expect(I18n).to receive(:translate).with(
           :"#{klass.i18n_scope}.ancestors.#{klass.model_name.i18n_key}.search.operator.names.#{name}.help",
           anything
       )
@@ -92,12 +92,12 @@ shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
     end
 
     it 'should pass other translation keys as default option' do
-      I18n.should_receive(:translate) do |_key, options|
-        options.should be_a Hash
+      expect(I18n).to receive(:translate) do |_key, options|
+        expect(options).to be_a Hash
 
         default = options[:default]
 
-        default.should be_an Array
+        expect(default).to be_an Array
 
         expect(
             default.all? { |key|
@@ -110,7 +110,7 @@ shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
     end
 
     it 'should pass #name of operator as name option' do
-      I18n.should_receive(:translate).with(
+      expect(I18n).to receive(:translate).with(
           anything,
           hash_including(name: name)
       )
@@ -119,7 +119,7 @@ shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
     end
 
     it 'should pass the human model name of #klass as model option' do
-      I18n.should_receive(:translate).with(
+      expect(I18n).to receive(:translate).with(
           anything,
           hash_including(model: klass.model_name.human)
       )
@@ -128,7 +128,7 @@ shared_examples_for 'Metasploit::Model::Search::Operator::Help' do
     end
 
     it 'should be translated correctly' do
-      help.should == help_template % { model: model, name: name }
+      expect(help).to eq(help_template % { model: model, name: name })
     end
   end
 end

--- a/spec/support/shared/examples/metasploit/model/translation.rb
+++ b/spec/support/shared/examples/metasploit/model/translation.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Model::Translation' do |options={}|
+RSpec.shared_examples_for 'Metasploit::Model::Translation' do |options={}|
   options.assert_valid_keys(:metasploit_model_ancestor)
 
   metasploit_model_ancestor = options.fetch(:metasploit_model_ancestor)
@@ -24,7 +24,7 @@ shared_examples_for 'Metasploit::Model::Translation' do |options={}|
       base_class.i18n_scope
     end
 
-    it { should == 'metasploit.model' }
+    it { is_expected.to eq('metasploit.model') }
   end
 
   context 'lookup_ancestors' do

--- a/spec/support/shared/examples/metasploit/model/translation.rb
+++ b/spec/support/shared/examples/metasploit/model/translation.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples_for 'Metasploit::Model::Translation' do |options={}|
           metasploit_model_ancestor.instance_variable_get :@_dependencies
         end
 
-        it { should include Metasploit::Model::Translation }
+        it { is_expected.to include Metasploit::Model::Translation }
       end
     end
   end
@@ -32,6 +32,6 @@ RSpec.shared_examples_for 'Metasploit::Model::Translation' do |options={}|
       base_class.lookup_ancestors
     end
 
-    it { should include metasploit_model_ancestor }
+    it { is_expected.to include metasploit_model_ancestor }
   end
 end

--- a/spec/support/shared/examples/search/query.rb
+++ b/spec/support/shared/examples/search/query.rb
@@ -35,8 +35,8 @@ RSpec.shared_examples_for 'search query' do |options={}|
           }
         end
 
-        it { should_not be_nil }
-        it { should be_valid }
+        it { is_expected.not_to be_nil }
+        it { is_expected.to be_valid }
       end
     end
   end

--- a/spec/support/shared/examples/search/query.rb
+++ b/spec/support/shared/examples/search/query.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'search query' do |options={}|
+RSpec.shared_examples_for 'search query' do |options={}|
   options.assert_valid_keys(:formatted_operator)
 
   formatted_operator = options.fetch(:formatted_operator)

--- a/spec/support/shared/examples/search_association.rb
+++ b/spec/support/shared/examples/search_association.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples_for 'search_association' do |association|
-  context association do
+  context association.to_s do
     let(:association_operators) do
       base_class.search_operator_by_name.select { |_name, operator|
         operator.respond_to?(:association) and operator.association == association

--- a/spec/support/shared/examples/search_association.rb
+++ b/spec/support/shared/examples/search_association.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'search_association' do |association|
+RSpec.shared_examples_for 'search_association' do |association|
   context association do
     let(:association_operators) do
       base_class.search_operator_by_name.select { |_name, operator|

--- a/spec/support/shared/examples/search_attribute.rb
+++ b/spec/support/shared/examples/search_attribute.rb
@@ -19,8 +19,8 @@ RSpec.shared_examples_for 'search_attribute' do |name, options={}|
           base_class.send(attribute_set_method_name)
         end
 
-        it { should be_a Set }
-        it { should_not be_empty }
+        it { is_expected.to be_a Set }
+        it { is_expected.not_to be_empty }
       end
     end
   end

--- a/spec/support/shared/examples/search_attribute.rb
+++ b/spec/support/shared/examples/search_attribute.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'search_attribute' do |name, options={}|
+RSpec.shared_examples_for 'search_attribute' do |name, options={}|
   options.assert_valid_keys(:type)
   type = options.fetch(:type)
 

--- a/spec/support/shared/examples/search_with.rb
+++ b/spec/support/shared/examples/search_with.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'search_with' do |operation_class, options={}|
+RSpec.shared_examples_for 'search_with' do |operation_class, options={}|
   name = options.fetch(:name)
 
   context name do

--- a/spec/support/shared/examples/search_with.rb
+++ b/spec/support/shared/examples/search_with.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples_for 'search_with' do |operation_class, options={}|
   name = options.fetch(:name)
 
-  context name do
+  context name.to_s do
     subject(:with_operator) do
       base_class.search_with_operator_by_name[name]
     end

--- a/spec/support/shared/examples/search_with.rb
+++ b/spec/support/shared/examples/search_with.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples_for 'search_with' do |operation_class, options={}|
       base_class.search_with_operator_by_name[name]
     end
 
-    it { should be_a operation_class }
+    it { is_expected.to be_a operation_class }
 
     options.each do |key, value|
       # skip :name since it use used to look up operator, so it's already been checked or with_operator would be `nil`


### PR DESCRIPTION
MSP-12656

Upgrade to rspec 3.1+ so that metasploit-version can be used so that it can generate proper documentation for versioning 1.0.0+ for staging/rails-4.0.

# Verification Steps
- [ ] `Gemfile.lock`
- [ ] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/model/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

Complete these steps on DESTINATION

## Version

### Compatible changes

- Incremented [`PATCH`](lib/metasploit/model/version.rb).

## JRuby
- [ ] `rvm use jruby@metasploit-model`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit-model`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`