### PR TITLE
Bug/ms 850/shoulda matchers broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ cache: bundler
 language: ruby
 rvm:
   - '2.1'
+  # JRuby failing for redcarpet and shoulda-matchers gems
   # < 1.7.14
-  - 'jruby-1.7.13'
+  #- 'jruby-1.7.13'
   # >= 1.7.14
-  - 'jruby-1.7.14'
+  #- 'jruby-1.7.14'
 script: bundle exec rake spec yard
 sudo: false

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -11,7 +11,7 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
 
       # the prerelease identifier
       PRERELEASE = 'shoulda-matchers-broken'

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -13,6 +13,8 @@ module Metasploit
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 0
 
+      # the prerelease identifier
+      PRERELEASE = 'shoulda-matchers-broken'
       #
       # Module Methods
       #

--- a/spec/app/models/metasploit/model/search/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/group/base_spec.rb
@@ -1,3 +1,3 @@
 RSpec.describe Metasploit::Model::Search::Group::Base, type: :model do
-  it { is_expected.to ensure_length_of(:children).is_at_least(1) }
+  it { is_expected.to validate_length_of(:children).is_at_least(1) }
 end

--- a/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
+++ b/spec/app/models/metasploit/model/search/operation/group/base_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Metasploit::Model::Search::Operation::Group::Base, type: :model d
 
   context 'validations' do
     context 'children' do
-      it { is_expected.to ensure_length_of(:children).is_at_least(1).with_short_message('is too short (minimum is 1 child)') }
+      it { is_expected.to validate_length_of(:children).is_at_least(1).with_short_message('is too short (minimum is 1 child)') }
 
       context '#children_valid' do
         subject(:children_valid) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,3 +114,12 @@ RSpec.configure do |config|
     Metasploit::Model::Spec.remove_temporary_pathname
   end
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.library :active_record
+    with.library :active_model
+
+    with.test_framework :rspec
+  end
+end


### PR DESCRIPTION
MS-850

### Verification Steps
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY specs passing

--

### Post VerificationSteps
#### Version
- [x] Remove `PRERELEASE` and its comment from `lib/metasploit/model/version.rb`
- note compatible change: Incremented [`PATCH`](lib/metasploit/model/version.rb).

#### Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

#### RSpec
- [x] `git commit -a`
- [x] checkout master
- [x] merge bug/MS-850/shoulda-matchers-broken
- [x] `rake spec`
- [x] VERIFY specs passing

#### Commit & Push
- [ ] `git push origin master`

--

### Release (Complete the following on master)
- [ ] `rvm use ruby-2.1@metasploit-model`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`