### PR TITLE
update to support rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
+dist: trusty
 group: stable
 sudo: false
 cache: bundler
 language: ruby
 addons:
-  postgresql: '9.3'
+  postgresql: '9.6'
   apt:
     packages:
       - graphviz
 rvm:
-  - 2.3.2
+  - 2.6.5
 before_install:
-  - gem update bundler
+  - gem install bundler
+  - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
+  - bundle install
+  - bundle exec rake --version
+  - bundle exec rake db:test:prepare
 script:
   - bundle exec rake spec
   - bundle exec rake yard

--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
 --markup markdown
+--plugin yard-metasploit-erd
 --private
 --protected
 {app,lib}/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gemspec
 group :development, :test do
   # supplies factories for producing model instance for specs
   # Version 4.1.0 or newer is needed to support generate calls without the 'FactoryGirl.' in factory definitions syntax.
-  gem 'factory_girl'
+  gem 'factory_bot'
   # auto-load factories from spec/factories
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
 end
 
 group :test do

--- a/app/validators/ip_format_validator.rb
+++ b/app/validators/ip_format_validator.rb
@@ -4,7 +4,7 @@ require 'ipaddr'
 class IpFormatValidator < ActiveModel::EachValidator
   # Validates that `value` is an IPv4 or IPv4 address.  Ranges in CIDR or netmask notation are not allowed.
   #
-  # @param record [#errors, ActiveRecord::Base] ActiveModel or ActiveRecord
+  # @param record [#errors, ApplicationRecord] ActiveModel or ActiveRecord
   # @param attribute [Symbol] name of IP address attribute.
   # @param value [String, nil] IP address.
   # @return [void]

--- a/app/validators/nil_validator.rb
+++ b/app/validators/nil_validator.rb
@@ -4,7 +4,7 @@
 class NilValidator < ActiveModel::EachValidator
   # Validates that `value` is `nil`.
   #
-  # @param record [#errors, ActiveRecord::Base] an ActiveModel or ActiveRecord
+  # @param record [#errors, ApplicationRecord] an ActiveModel or ActiveRecord
   # @param attribute [Symbol] name of attribute being validated.
   # @param value [#nil?] value of `attribute` to check with `nil?`
   # @return [void]

--- a/app/validators/parameters_validator.rb
+++ b/app/validators/parameters_validator.rb
@@ -7,7 +7,7 @@ class ParametersValidator < ActiveModel::EachValidator
   # Validates that attribute's value is Array<Array(String, String)> which is the only valid type signature for
   # serialized parameters.  Errors are specific to the how different `value` is compared to correct format.
   #
-  # @param record [#errors, ActiveRecord::Base] ActiveModel or ActiveRecord
+  # @param record [#errors, ApplicationRecord] ActiveModel or ActiveRecord
   # @param attribute [Symbol] serialized parameters attribute name.
   # @param value [Object, nil, Array, Array<Array>, Array<Array(String, String)>] serialized parameters.
   # @return [void]

--- a/app/validators/password_is_strong_validator.rb
+++ b/app/validators/password_is_strong_validator.rb
@@ -19,7 +19,7 @@ class PasswordIsStrongValidator < ActiveModel::EachValidator
   # * SHOULD NOT be in {COMMON_PASSWORDS}.
   # * SHOULD NOT repetitions.
   #
-  # @param record [#errors, #username, ActiveRecord::Base] ActiveModel or ActiveRecord that supports #username method.
+  # @param record [#errors, #username, ApplicationRecord] ActiveModel or ActiveRecord that supports #username method.
   # @param attribute [Symbol] password attribute name.
   # @param value [String] a password.
   # @return [void]

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/metasploit/model/engine', __dir__)
+APP_PATH = File.expand_path('../test/dummy/config/application', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/lib/metasploit/model/base.rb
+++ b/lib/metasploit/model/base.rb
@@ -1,5 +1,5 @@
 # Superclass for all Metasploit::Models.  Just adds a default {#initialize} to make models mimic behavior of
-# ActiveRecord::Base subclasses.
+# ApplicationRecord subclasses.
 class Metasploit::Model::Base
   include ActiveModel::Validations
 

--- a/lib/metasploit/model/engine.rb
+++ b/lib/metasploit/model/engine.rb
@@ -22,12 +22,12 @@ class Metasploit::Model::Engine < Rails::Engine
   end
 
   initializer 'metasploit-model.prepend_factory_path', :after => 'factory_girl.set_factory_paths' do
-    if defined? FactoryGirl
+    if defined? FactoryBot
       relative_definition_file_path = config.generators.options[:factory_girl][:dir]
       definition_file_path = root.join(relative_definition_file_path)
 
       # unshift so that dependent gems can modify metasploit-model's factories
-      FactoryGirl.definition_file_paths.unshift definition_file_path
+      FactoryBot.definition_file_paths.unshift definition_file_path
     end
   end
 end

--- a/lib/metasploit/model/search/attribute.rb
+++ b/lib/metasploit/model/search/attribute.rb
@@ -16,7 +16,7 @@
 # The help for each operator is uses the `I18n` system, so the help for an attribute operator on a given class can
 # added to `config/locales/<lang>.yml`.  The scope of the lookup, under the language key is the `Class`'s
 # `i18n_scope`, which is `metasploit.model` if the `Class` includes {Metasploit::Model::Translation} or
-# `active_record` for `ActiveRecord::Base` subclasses.  Under the `i18n_scope`, any `Module#ancestor`'s
+# `active_record` for `ApplicationRecord` subclasses.  Under the `i18n_scope`, any `Module#ancestor`'s
 # `model_name.i18n_key` can be used to look up the help for an attribute's operator.  This allows for super
 # classes or mixins to define the search operator help for subclasses.
 #

--- a/lib/metasploit/model/translation.rb
+++ b/lib/metasploit/model/translation.rb
@@ -1,6 +1,6 @@
 # ActiveRecord::Translation is a dirty bastard and overrides `ActiveModel::Translation#lookup_ancestors`, so that it
 # will only count superclasses, and not all ancestors.  Metasploit::Model needs the original behavior so that its
-# {Metasploit::Model::Module} modules can supply translations to both `ActiveRecord::Base` descendants in `Mdm` and
+# {Metasploit::Model::Module} modules can supply translations to both `ApplicationRecord` descendants in `Mdm` and
 # `ActiveModel` descendants in `Metasploit::Framework`
 #
 # @see https://github.com/rails/rails/issues/11409

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module Model
     # VERSION is managed by GemRelease
-    VERSION = '2.0.5'
+    VERSION = '3.0.0'
   
     # @return [String]
     #

--- a/metasploit-model.gemspec
+++ b/metasploit-model.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'metasploit-yard'
   spec.add_development_dependency 'metasploit-erd'
   spec.add_development_dependency 'rake'

--- a/metasploit-model.gemspec
+++ b/metasploit-model.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Metasploit Model Mixins and Validators}
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w{app/models app/validators lib}
 

--- a/metasploit-model.gemspec
+++ b/metasploit-model.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
 
   # Dependency loading
 
-  spec.add_runtime_dependency 'activemodel', '~> 4.2.6'
-  spec.add_runtime_dependency 'activesupport', '~> 4.2.6'
+  spec.add_runtime_dependency 'activemodel', '~> 5.2.2'
+  spec.add_runtime_dependency 'activesupport', '~> 5.2.2'
 
-  spec.add_runtime_dependency 'railties', '~> 4.2.6'
+  spec.add_runtime_dependency 'railties', '~> 5.2.2'
 
   if RUBY_PLATFORM =~ /java/
     # markdown formatting for yard

--- a/spec/app/models/metasploit/model/association/reflection_spec.rb
+++ b/spec/app/models/metasploit/model/association/reflection_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Metasploit::Model::Association::Reflection, type: :model do
 
 
     let(:class_name) do
-      FactoryGirl.generate :metasploit_model_association_reflection_class_name
+      FactoryBot.generate :metasploit_model_association_reflection_class_name
     end
 
     let(:class_name_class) do
@@ -24,7 +24,7 @@ RSpec.describe Metasploit::Model::Association::Reflection, type: :model do
     end
 
     let(:name) do
-      FactoryGirl.generate :metasploit_model_association_reflection_name
+      FactoryBot.generate :metasploit_model_association_reflection_name
     end
 
     let(:reflection) do

--- a/spec/app/models/metasploit/model/search/operator/association_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/association_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Association, type: :model do
   end
 
   let(:association) do
-    FactoryGirl.generate :metasploit_model_search_operator_association_association
+    FactoryBot.generate :metasploit_model_search_operator_association_association
   end
 
   let(:source_operator) do

--- a/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
+++ b/spec/app/models/metasploit/model/search/operator/attribute_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Metasploit::Model::Search::Operator::Attribute, type: :model do
     end
 
     let(:attribute) do
-      FactoryGirl.generate :metasploit_model_search_operator_attribute_attribute
+      FactoryBot.generate :metasploit_model_search_operator_attribute_attribute
     end
 
     let(:attribute_operator) do

--- a/spec/dummy/app/models/application_record.rb
+++ b/spec/dummy/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ApplicationRecord
+  self.abstract_class = true
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -3,6 +3,7 @@ require File.expand_path('../boot', __FILE__)
 # Pick the frameworks you want:
 require 'active_model/railtie'
 require 'action_controller/railtie'
+require 'active_record/railtie'
 
 Bundler.require(*Rails.groups)
 
@@ -40,11 +41,6 @@ module Dummy
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
-    # Enable the asset pipeline
-    config.assets.enabled = false
-
-    # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
   end
 end
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -20,16 +20,6 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
-
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )

--- a/spec/factories/metasploit/model/association/reflections.rb
+++ b/spec/factories/metasploit/model/association/reflections.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :metasploit_model_association_reflection_class_name do |n|
     "Metasploit::Model::Association::Reflection::Class#{n}"
   end

--- a/spec/factories/metasploit/model/bases.rb
+++ b/spec/factories/metasploit/model/bases.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   trait :metasploit_model_base do
     to_create do |instance|
       # validate so before validation derivation occurs to mimic create for ActiveRecord.

--- a/spec/factories/metasploit/model/search/operator/associations.rb
+++ b/spec/factories/metasploit/model/search/operator/associations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :metasploit_model_search_operator_association_association do |n|
     "metasploit_model_search_operator_association_association#{n}".to_sym
   end

--- a/spec/factories/metasploit/model/search/operator/attributes.rb
+++ b/spec/factories/metasploit/model/search/operator/attributes.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :metasploit_model_search_operator_attribute_attribute do |n|
     "metasploit_model_search_operator_attribute_attribute#{n}".to_sym
   end

--- a/spec/factories/metasploit/model/search/operator/bases.rb
+++ b/spec/factories/metasploit/model/search/operator/bases.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :metasploit_model_search_operator_base_name do |n|
     "metasploit_model_search_operator_base_name#{n}".to_sym
   end

--- a/spec/lib/metasploit/model/engine_spec.rb
+++ b/spec/lib/metasploit/model/engine_spec.rb
@@ -106,11 +106,11 @@ RSpec.describe Metasploit::Model::Engine do
           initializer.run
         end
 
-        context 'with FactoryGirl defined' do
-          it 'should prepend full path to spec/factories to FactoryGirl.definition_file_paths' do
+        context 'with FactoryBot defined' do
+          it 'should prepend full path to spec/factories to FactoryBot.definition_file_paths' do
             definition_file_path = Metasploit::Model::Engine.root.join('spec', 'factories')
 
-            expect(FactoryGirl.definition_file_paths).to receive(:unshift).with(definition_file_path)
+            expect(FactoryBot.definition_file_paths).to receive(:unshift).with(definition_file_path)
 
             run
           end

--- a/spec/lib/metasploit/model/search/attribute_spec.rb
+++ b/spec/lib/metasploit/model/search/attribute_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Metasploit::Model::Search::Attribute do
   context 'search_attribute' do
     context 'with attribute' do
       let(:attribute) do
-        FactoryGirl.generate :metasploit_model_search_operator_attribute_attribute
+        FactoryBot.generate :metasploit_model_search_operator_attribute_attribute
       end
 
       context 'with :type' do
         let(:type) do
-          FactoryGirl.generate :metasploit_model_search_operator_attribute_type
+          FactoryBot.generate :metasploit_model_search_operator_attribute_type
         end
 
         context 'operator' do


### PR DESCRIPTION
Depends on https://github.com/rapid7/metasploit-erd/pull/10
Depends on https://github.com/rapid7/metasploit-yard/pull/8

Updates dependencies to support Rails 5.2.

Due to compatibility options for Rails dependency this reflects a breaking change.

Set version to 3.0.0, open to input on version as 2.1.0 since no significant code changes.
