### PR TITLE
Added Address Format Validator And Updated Spec Testing

### DIFF
--- a/app/validators/address_format_validator.rb
+++ b/app/validators/address_format_validator.rb
@@ -1,0 +1,26 @@
+require 'ipaddr'
+
+# Validates that attribute is a valid address.
+class AddressFormatValidator < ActiveModel::EachValidator
+  # Validates that `attribute`'s `value` on `object` is a valid address.
+  #
+  # @param record [#errors, ApplicationRecord] ActiveModel or ActiveRecord
+  # @param attribute [Symbol] name of address attribute.
+  # @param value [String, nil] address.
+  # @return [void]
+  def validate_each(object, attribute, value)
+    error_message_block = lambda{ object.errors.add attribute, "must be a valid (IP or hostname) address" }
+    begin
+      # Checks for valid IP addresses
+      if value.is_a? IPAddr
+        potential_ip = value.dup
+      else
+        potential_ip = IPAddr.new(value)
+      end
+      error_message_block.call unless potential_ip.ipv4? || potential_ip.ipv6?
+    rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError, ArgumentError
+      # IP address resolution failed, checks for valid hostname
+      error_message_block.call unless (value && value.match?(/\A#{URI::PATTERN::HOSTNAME}\z/))
+    end
+  end
+end

--- a/app/validators/ip_format_validator.rb
+++ b/app/validators/ip_format_validator.rb
@@ -1,31 +1,25 @@
 require 'ipaddr'
 
-# Validates that value is an IPv4 or IPv6 address.
+# Validates that value is a valid IPv4 or IPv6 address.
 class IpFormatValidator < ActiveModel::EachValidator
-  # Validates that `value` is an IPv4 or IPv4 address.  Ranges in CIDR or netmask notation are not allowed.
+  # Validates that `attribute`'s `value` on `object` is a valid IPv4 or IPv6 address.
   #
   # @param record [#errors, ApplicationRecord] ActiveModel or ActiveRecord
   # @param attribute [Symbol] name of IP address attribute.
   # @param value [String, nil] IP address.
   # @return [void]
-  # @see IPAddr#ipv4?
-  # @see IPAddr#ipv6?
-  def validate_each(record, attribute, value)
+  def validate_each(object, attribute, value)
+    error_message_block = lambda{ object.errors.add attribute, "must be a valid IPv4 or IPv6 address" }
     begin
-      potential_ip = IPAddr.new(value)
-    rescue ArgumentError
-      record.errors[attribute] << 'must be a valid IPv4 or IPv6 address'
-    else
-      # if it includes a netmask, then it's not an IP address, but an IP range.
-      if potential_ip.ipv4?
-        if potential_ip.instance_variable_get(:@mask_addr) != IPAddr::IN4MASK
-          record.errors[attribute] << 'must be a valid IPv4 or IPv6 address and not an IPv4 address range in CIDR or netmask notation'
-        end
-      elsif potential_ip.ipv6?
-        if potential_ip.instance_variable_get(:@mask_addr) != IPAddr::IN6MASK
-          record.errors[attribute] << 'must be a valid IPv4 or IPv6 address and not an IPv6 address range in CIDR or netmask notation'
-        end
+      if value.is_a? IPAddr
+        potential_ip = value.dup
+      else
+        potential_ip = IPAddr.new(value)
       end
+
+      error_message_block.call unless potential_ip.ipv4? || potential_ip.ipv6?
+    rescue ArgumentError
+      error_message_block.call
     end
   end
 end

--- a/app/validators/nil_validator.rb
+++ b/app/validators/nil_validator.rb
@@ -10,7 +10,7 @@ class NilValidator < ActiveModel::EachValidator
   # @return [void]
   def validate_each(record, attribute, value)
     unless value.nil?
-      record.errors[attribute] << 'must be nil'
+      record.errors.add attribute, 'must be nil'
     end
   end
 end

--- a/app/validators/parameters_validator.rb
+++ b/app/validators/parameters_validator.rb
@@ -1,11 +1,19 @@
 # Validates that attribute's value is Array<Array(String, String)> which is the only valid type signature for serialized
 # parameters.
 class ParametersValidator < ActiveModel::EachValidator
+  #
+  # CONSTANTS
+  #
+
   # Sentence explaining the valid type signature for parameters.
   TYPE_SIGNATURE_SENTENCE = 'Valid parameters are an Array<Array(String, String)>.'
 
-  # Validates that attribute's value is Array<Array(String, String)> which is the only valid type signature for
-  # serialized parameters.  Errors are specific to the how different `value` is compared to correct format.
+  #
+  # Instance Methods
+  #
+
+  # Validates that `attribute`'s `value` on `record` is `Array<Array(String, String)>` which is the only valid type
+  # signature for serialized parameters.
   #
   # @param record [#errors, ApplicationRecord] ActiveModel or ActiveRecord
   # @param attribute [Symbol] serialized parameters attribute name.
@@ -28,7 +36,7 @@ class ParametersValidator < ActiveModel::EachValidator
                 :index => index
             )
 
-            record.errors[attribute] << length_error
+            record.errors.add attribute, length_error
           else
             parameter_name = element.first
 
@@ -39,7 +47,7 @@ class ParametersValidator < ActiveModel::EachValidator
                     :index => index,
                     :prefix => "has blank parameter name"
                 )
-                record.errors[attribute] << error
+                record.errors.add attribute, error
               end
             else
               error = error_at(
@@ -47,7 +55,7 @@ class ParametersValidator < ActiveModel::EachValidator
                   :index => index,
                   :prefix => "has non-String parameter name (#{parameter_name.inspect})"
               )
-              record.errors[attribute] << error
+              record.errors.add attribute, error
             end
 
             parameter_value = element.second
@@ -58,7 +66,7 @@ class ParametersValidator < ActiveModel::EachValidator
                   :index => index,
                   :prefix => "has non-String parameter value (#{parameter_value.inspect})"
               )
-              record.errors[attribute] << error
+              record.errors.add attribute, error
             end
           end
         else
@@ -67,11 +75,11 @@ class ParametersValidator < ActiveModel::EachValidator
               :index => index,
               :prefix => 'has non-Array'
           )
-          record.errors[attribute] << error
+          record.errors.add attribute, error
         end
       end
     else
-      record.errors[attribute] << "is not an Array.  #{TYPE_SIGNATURE_SENTENCE}"
+      record.errors.add attribute, "is not an Array.  #{TYPE_SIGNATURE_SENTENCE}"
     end
   end
 

--- a/app/validators/password_is_strong_validator.rb
+++ b/app/validators/password_is_strong_validator.rb
@@ -4,20 +4,18 @@ class PasswordIsStrongValidator < ActiveModel::EachValidator
   # CONSTANTS
   #
 
-  # Password that are used too often and will be easily guessed.
+  # Known passwords that should NOT be allowed and should be considered weak.
   COMMON_PASSWORDS = %w{
-			password pass root admin metasploit
-			msf 123456 qwerty abc123 letmein monkey link182 demo
-			changeme test1234 rapid7
-		}
+      password pass root admin metasploit
+      msf 123456 qwerty abc123 letmein monkey link182 demo
+      changeme test1234 rapid7
+    }
 
-  # Validates that `value` is a strong password.  A password is strong if it meets the following rules:
-  # * SHOULD contain at least one letter.
-  # * SHOULD contain at least one digit.
-  # * SHOULD contain at least one special character.
-  # * SHOULD NOT contain `record.username` (case-insensitive).
-  # * SHOULD NOT be in {COMMON_PASSWORDS}.
-  # * SHOULD NOT repetitions.
+  # Special characters that are considered to strength passwords and are required once in a strong password.
+  SPECIAL_CHARS = %q{!@"#$%&'()*+,-./:;<=>?[\\]^_`{|}~ }
+
+  # Validates that the `attribute`'s `value` on `record` contains letters, numbers, and at least one special character
+  # without containing the `record.username`, any {COMMON_PASSWORDS} or repetition.
   #
   # @param record [#errors, #username, ApplicationRecord] ActiveModel or ActiveRecord that supports #username method.
   # @param attribute [Symbol] password attribute name.
@@ -27,30 +25,101 @@ class PasswordIsStrongValidator < ActiveModel::EachValidator
     return if value.blank?
 
     if is_simple?(value)
-      record.errors[attribute] << 'must contain letters, numbers, and at least one special character'
+      record.errors.add attribute, 'must contain letters, numbers, and at least one special character'
     end
 
-    if contains_username?(record.username, value)
-      record.errors[attribute] << 'must not contain the username'
+    if contains_username?(record.username, value) && !record.username.blank?
+      record.errors.add attribute, 'must not contain the username'
     end
 
     if is_common_password?(value)
-      record.errors[attribute] << 'must not be a common password'
+      record.errors.add attribute, 'must not be a common password'
     end
 
-    if contains_repetition?(value)
-      record.errors[attribute] << 'must not be a predictable sequence of characters'
+    if is_only_repetition?(value)
+      record.errors.add attribute, 'must not be a predictable sequence of characters'
     end
   end
 
   private
 
-  # Password repetition (quite basic) -- no "aaaaaa" or "ababab" or "abcabc" or
-  # "abcdabcd" (but note that the user can use "aaaaaab" or something).
+  # Returns whether the password is simple.
+  #
+  # @return [false] if password contains a letter, digit and special character.
+  # @return [true] otherwise
+  def is_simple?(password)
+    not (password =~ /[A-Za-z]/ and password =~ /[0-9]/ and password =~ /[#{Regexp.escape(SPECIAL_CHARS)}]/)
+  end
+
+  # Returns whether username is in password (case-insensitively).
+  #
+  # @return [true] if `username` is in `password`.
+  # @return [false] unless `username` is in `password`.
+  def contains_username?(username, password)
+    !!(password =~ /#{username}/i)
+  end
+
+  # Returns whether `password` is in {COMMON_PASSWORDS} or a simple variation of a password in {COMMON_PASSWORDS}.
   #
   # @param password [String]
   # @return [Boolean]
-  def contains_repetition?(password)
+  def is_common_password?(password)
+    COMMON_PASSWORDS.each do |pw|
+      common_pw = [pw] # pw + "!", pw + "1", pw + "12", pw + "123", pw + "1234"]
+      common_pw += mutate_pass(pw)
+      common_pw.each do |common_pass|
+        if password.downcase =~ /#{common_pass}[\d!]*/
+          return true
+        end
+      end
+    end
+    false
+  end
+
+  # Returns a leet mutated variant of the original password
+  #
+  # @param password [String]
+  # @return [String] containing the password with leet mutations
+  def mutate_pass(password)
+    mutations = {
+        'a' => '@',
+        'o' => '0',
+        'e' => '3',
+        's' => '$',
+        't' => '7',
+        'l' => '1'
+    }
+
+    iterations = mutations.keys.dup
+    results = []
+
+    # Find PowerSet of all possible mutation combinations
+    iterations = iterations.inject([[]]){|c,y|r=[];c.each{|i|r<<i;r<<i+[y]};r}
+
+    # Iterate through combinations to create each possible mutation
+    iterations.each do |iteration|
+      next if iteration.flatten.empty?
+      first = iteration.shift
+      intermediate = password.gsub(/#{first}/i, mutations[first])
+      iteration.each do |mutator|
+        next unless mutator.kind_of? String
+        intermediate.gsub!(/#{mutator}/i, mutations[mutator])
+      end
+      results << intermediate
+    end
+
+    return results
+  end
+
+
+  # Returns whether `password` is only composed of repetitions
+  #
+  # @param password [String]
+  # @return [Boolean]
+  def is_only_repetition?(password)
+    # Password repetition (quite basic) -- no "aaaaaa" or "ababab" or "abcabc" or
+    # "abcdabcd" (but note that the user can use "aaaaaab" or something).
+
     if password.scan(/./).uniq.size < 2
       return true
     end
@@ -68,48 +137,5 @@ class PasswordIsStrongValidator < ActiveModel::EachValidator
     end
 
     false
-  end
-
-  # Whether username is in password (case-insensitively).
-  #
-  # @return [false] if `password` is blank.
-  # @return [false] if `username` is blank.
-  # @return [false] unless `username` is in `password`.
-  # @return [true] if `username` is in `password`.
-  def contains_username?(username, password)
-    contains = false
-
-    unless password.blank? or username.blank?
-      escaped_username = Regexp.escape(username)
-      username_regexp = Regexp.new(escaped_username, Regexp::IGNORECASE)
-
-      if username_regexp.match(password)
-        contains = true
-      end
-    end
-
-    contains
-  end
-
-  # Whether `password` is in {COMMON_PASSWORDS} or a simple variation of a password in {COMMON_PASSWORDS}.
-  #
-  # @param password [String]
-  # @return [Boolean]
-  def is_common_password?(password)
-    COMMON_PASSWORDS.each do |pw|
-      common_pw = [pw, pw + "!", pw + "1", pw + "12", pw + "123", pw + "1234"]
-      if common_pw.include?(password.downcase)
-        return true
-      end
-    end
-    false
-  end
-
-  # Returns whether the password is simple.
-  #
-  # @return [false] if password contains a letter, digit and special character.
-  # @return [true] otherwise
-  def is_simple?(password)
-    not (password =~ /[A-Za-z]/ and password =~ /[0-9]/ and password =~ /[\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f\x3a\x3b\x3c\x3d\x3e\x3f\x5b\x5c\x5d\x5e\x5f\x60\x7b\x7c\x7d\x7e]/)
   end
 end

--- a/app/validators/password_is_strong_validator.rb
+++ b/app/validators/password_is_strong_validator.rb
@@ -28,7 +28,7 @@ class PasswordIsStrongValidator < ActiveModel::EachValidator
       record.errors.add attribute, 'must contain letters, numbers, and at least one special character'
     end
 
-    if contains_username?(record.username, value) && !record.username.blank?
+    if !record.username.blank? && contains_username?(record.username, value)
       record.errors.add attribute, 'must not contain the username'
     end
 

--- a/lib/metasploit/model.rb
+++ b/lib/metasploit/model.rb
@@ -9,6 +9,7 @@
 require 'active_model'
 require 'active_support'
 
+autoload :AddressFormatValidator, 'address_format_validator'
 autoload :IpFormatValidator, 'ip_format_validator'
 autoload :NilValidator, 'nil_validator'
 autoload :ParametersValidator, 'parameters_validator'

--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module Model
     # VERSION is managed by GemRelease
-    VERSION = '3.0.1'
+    VERSION = '3.1.0'
   
     # @return [String]
     #

--- a/spec/app/validators/address_format_validator_spec.rb
+++ b/spec/app/validators/address_format_validator_spec.rb
@@ -1,0 +1,136 @@
+RSpec.describe AddressFormatValidator do
+  subject(:address_format_validator) do
+    described_class.new(
+        :attributes => attributes
+    )
+  end
+
+  let(:attribute) do
+    :address
+  end
+
+  let(:attributes) do
+    [
+        attribute
+    ]
+  end
+
+  context '#validate_each' do
+    subject(:validate_each) do
+      address_format_validator.validate_each(record, attribute, value)
+    end
+
+    let(:error) do
+      'must be a valid (IP or hostname) address'
+    end
+
+    let(:record) do
+      record_class.new
+    end
+
+    let(:record_class) do
+      # capture for Class.new scope
+      attribute = self.attribute
+
+      Class.new do
+        include ActiveModel::Validations
+
+        #
+        # Validations
+        #
+
+        validates attribute,
+                  :address_format => true
+      end
+    end
+
+    context 'address' do
+      context 'in IPv4 format' do
+        let(:value) do
+          '192.168.0.1'
+        end
+
+        it 'should not record any errors' do
+          validate_each
+
+          expect(record.errors).to be_empty
+        end
+      end
+
+      context 'in IPv6 format' do
+        let(:value) do
+          '::1'
+        end
+
+        it 'should not record any errors' do
+          validate_each
+
+          expect(record.errors).to be_empty
+        end
+      end
+
+      context 'with a valid hostname' do
+        let(:value) do
+          'testvalue.test.com'
+        end
+
+        it 'should not record any errors' do
+          validate_each
+
+          expect(record.errors).to be_empty
+        end
+      end
+
+      context 'with localhost' do
+        let(:value) do
+          'localhost'
+        end
+
+        it 'should not record any errors' do
+          validate_each
+
+          expect(record.errors).to be_empty
+        end
+      end
+
+      context 'with blank address' do
+        let(:value) do
+          ''
+        end
+
+        it 'should record error' do
+          validate_each
+
+          expect(record.errors[attribute]).to include(error)
+        end
+      end
+
+      context 'with nil value' do
+        let(:value) do
+          nil
+        end
+
+        it 'should record error on attribute' do
+          validate_each
+
+          expect(record.errors[attribute]).to include(error)
+        end
+      end
+
+      context 'with a malformed hostname should record an error' do
+        invalid_hostnames = ['testvalue.test.com:', 'testvalue-.test.com', '[testvalue.test.com]']
+        invalid_hostnames.each do | entry |
+          let(:value) do
+            entry
+          end
+
+          it 'should record an error on attribute' do
+            validate_each
+            expect(record.errors[attribute]).to include(error)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/app/validators/ip_format_validator_spec.rb
+++ b/spec/app/validators/ip_format_validator_spec.rb
@@ -69,30 +69,6 @@ RSpec.describe IpFormatValidator do
         end
       end
 
-      context 'with IPv4 range' do
-        let(:value) do
-          '127.0.0.1/8'
-        end
-
-        it 'should record error' do
-          validate_each
-
-          expect(record.errors[attribute]).to include("#{error} and not an IPv4 address range in CIDR or netmask notation")
-        end
-      end
-
-      context 'with IPv6 range' do
-        let(:value) do
-          '3ffe:505:2::1/48'
-        end
-
-        it 'should record error' do
-          validate_each
-
-          expect(record.errors[attribute]).to include("#{error} and not an IPv6 address range in CIDR or netmask notation")
-        end
-      end
-
       context 'without IPv4 or IPv6 address' do
         let(:value) do
           'localhost'

--- a/spec/app/validators/password_is_strong_validator_spec.rb
+++ b/spec/app/validators/password_is_strong_validator_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe PasswordIsStrongValidator do
     ]
   end
 
-  context '#contains_repetition' do
-    subject(:contains_repetition?) do
-      password_is_strong_validator.send(:contains_repetition?, password)
+  context '#is_only_repetition' do
+    subject(:is_only_repetition?) do
+      password_is_strong_validator.send(:is_only_repetition?, password)
     end
 
     context 'with all the same character' do
@@ -56,8 +56,8 @@ RSpec.describe PasswordIsStrongValidator do
       let(:password) do
         'abcdefgh'
       end
-
       it { is_expected.to eq(false) }
+
     end
   end
 
@@ -66,59 +66,48 @@ RSpec.describe PasswordIsStrongValidator do
       password_is_strong_validator.send(:contains_username?, username, password)
     end
 
-    let(:username) do
-      ''
-    end
-
-    context 'with blank password' do
-      let(:password) do
-        ''
+    context 'without blank username' do
+      let(:username) do
+        'username'
       end
 
-      it { is_expected.to eq(false) }
-    end
-
-    context 'without blank password' do
-      let(:password) do
-        'password'
-      end
-
-      context 'with blank username' do
-        let(:username) do
+      context 'with blank password' do
+        let(:password) do
           ''
         end
-
         it { is_expected.to eq(false) }
       end
 
-      context 'without blank username' do
+      context 'with reserved regex characters in username' do
         let(:username) do
-          'username'
+          "user(with)regex"
         end
 
-        it 'should escape username' do
-          expect(Regexp).to receive(:escape).with(username).and_call_original
-
-          contains_username?
+        context 'with username in password' do
+          let(:password) do
+            "myPassworduser(with)regexValue"
+          end
+          it { is_expected.to eq(false)}
         end
+      end
 
-        context 'with matching password' do
-          context 'of different case' do
-            let(:password) do
-              username.titleize
-            end
-
-            it { is_expected.to eq(true) }
+      context 'with matching password' do
+        context 'of different case' do
+          let(:password) do
+            username.titleize
           end
 
-          context 'of same case' do
-            let(:password) do
-              username
-            end
-
-            it { is_expected.to eq(true) }
-          end
+          it { is_expected.to eq(true) }
         end
+
+        context 'of same case' do
+          let(:password) do
+            username
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
       end
     end
   end
@@ -231,7 +220,7 @@ RSpec.describe PasswordIsStrongValidator do
 
             context 'without repetition' do
               let(:value) do
-                'A$uperg00dp@ssw0rd'
+                'A$uperg00dp@sw0rd'
               end
 
               it 'should not record any errors' do


### PR DESCRIPTION
## In Particular:
- Updated all existing validators with content from `metasploit_data_models`
- Added `address_format_validator.rb` to validate hostnames and IPv4/v6 addresses
- Added `address_format_valdiator_spec.rb` to ensure the `AddressFormatValidator` behaves as expected
- Updated representative spec testing for the updated validators
## Verification:
- [ ] Create `database.yml` from the example file
- [ ] Perform a database refresh: `$ rake db:drop db:create db:migrate`
- [ ] Perform a rake spec test: `$ rake spec`
- [ ] **Verify** that the spec test finishes with no errors