### PR TITLE
update authors and do not include `bin` in gem

### DIFF
--- a/metasploit-model.gemspec
+++ b/metasploit-model.gemspec
@@ -6,12 +6,14 @@ require 'metasploit/model/version'
 Gem::Specification.new do |spec|
   spec.name          = 'metasploit-model'
   spec.version       = Metasploit::Model::VERSION
-  spec.authors       = ['Luke Imhoff']
-  spec.email         = ['luke_imhoff@rapid7.com']
+  spec.authors       = ['Metasploit Hackers']
+  spec.email         = ['msfdev@metasploit.com']
   spec.description   = %q{Common code, such as validators and mixins, that are shared between ActiveModels in metasploit-framework and ActiveRecords in metasploit_data_models.}
   spec.summary       = %q{Metasploit Model Mixins and Validators}
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($/).reject { |file|
+    file =~ /^bin/
+  }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w{app/models app/validators lib}
 


### PR DESCRIPTION
Fix #53 

* authors for this gem are updated to refer to the metasploit team maintaining the code
* Rails 5 required `bin/rails` be added locally.  This file needed to be excuded from gem assets