### PR TITLE
address ruby 2.7 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     packages:
       - graphviz
 rvm:
-  - 2.6.5
+  - 2.7.2
 before_install:
   - gem install bundler
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml

--- a/lib/metasploit/model/file.rb
+++ b/lib/metasploit/model/file.rb
@@ -41,5 +41,6 @@ if RUBY_PLATFORM =~ /java/ && Gem::Version.new(JRUBY_VERSION) < Gem::Version.new
     end
   end
 else
+  # Alias for ::File when not in jruby.
   Metasploit::Model::File = ::File
 end

--- a/lib/metasploit/model/search/operator/help.rb
+++ b/lib/metasploit/model/search/operator/help.rb
@@ -72,6 +72,6 @@ module Metasploit::Model::Search::Operator::Help
         name: name
     }
 
-    ::I18n.translate(key, options)
+    ::I18n.translate(key, **options)
   end
 end

--- a/metasploit-model.gemspec
+++ b/metasploit-model.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w{app/models app/validators lib}
 
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_development_dependency 'metasploit-yard'
   spec.add_development_dependency 'metasploit-erd'

--- a/metasploit-model.gemspec
+++ b/metasploit-model.gemspec
@@ -22,10 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'metasploit-yard'
   spec.add_development_dependency 'metasploit-erd'
   spec.add_development_dependency 'rake'
-
-  # documentation
-  # 0.8.7.4 has a bug where attribute setters show up as undocumented
-  spec.add_development_dependency 'yard', '< 0.8.7.4'
+  spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'e2mmap'
 
   # Dependency loading
 


### PR DESCRIPTION
* updates min ruby version to 2.4 for passing specs
* address keyword arguments hash deprecation