### PR TITLE
update to Rails 6.x compatible

### DIFF
--- a/lib/metasploit/model/version.rb
+++ b/lib/metasploit/model/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module Model
     # VERSION is managed by GemRelease
-    VERSION = '3.1.5'
+    VERSION = '4.0.0'
   
     # @return [String]
     #

--- a/metasploit-model.gemspec
+++ b/metasploit-model.gemspec
@@ -27,10 +27,10 @@ Gem::Specification.new do |spec|
 
   # Dependency loading
 
-  spec.add_runtime_dependency 'activemodel', '~> 5.2.2'
-  spec.add_runtime_dependency 'activesupport', '~> 5.2.2'
+  spec.add_runtime_dependency 'activemodel', '~> 6.0'
+  spec.add_runtime_dependency 'activesupport', '~> 6.0'
 
-  spec.add_runtime_dependency 'railties', '~> 5.2.2'
+  spec.add_runtime_dependency 'railties', '~> 6.0'
 
   if RUBY_PLATFORM =~ /java/
     # markdown formatting for yard


### PR DESCRIPTION
Allow usage with Rails 6.x

Depends on https://github.com/rapid7/metasploit-erd/pull/12 land and release.