### PR TITLE
Update Ubuntu 18.04 to 20.04 in Github CI script

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,17 +46,15 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.6
           - 2.7
           - 3.0
           - 3.1
         os:
-          - ubuntu-18.04
-          - ubuntu-22.04
+          - ubuntu-20.04
+          - ubuntu-latest
         exclude:
-          - { os: ubuntu-22.04, ruby: 2.6 }
-          - { os: ubuntu-22.04, ruby: 2.7 }
-          - { os: ubuntu-22.04, ruby: 3.0 }
+          - { os: ubuntu-latest, ruby: 2.7 }
+          - { os: ubuntu-latest, ruby: 3.0 }
 
     env:
       RAILS_ENV: test


### PR DESCRIPTION
Updates Github CI script to run 20.04 for now as Ubuntu 18.04 [EOL](https://endoflife.software/operating-systems/linux/ubuntu) was announced, updating early to avoid confusion with the brownout period:

> This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see https://github.com/actions/runner-images/issues/6002

Also removes Ruby 2.6 support, as it's officially end of life:
https://www.ruby-lang.org/en/downloads/branches/