### PR TITLE
Remove hardcoded secret

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,16 +46,12 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - '2.7'
-          - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         os:
-          - ubuntu-18.04
           - ubuntu-22.04
-        exclude:
-          - { os: ubuntu-22.04, ruby: '2.7' }
-          - { os: ubuntu-22.04, ruby: '3.0' }
+          - ubuntu-24.04
 
     env:
       RAILS_ENV: test

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = 'f04f565f9a4db0f0af88f4bd8b79952d139b02434b889a7c7bb3fe83405e9032409bd16bca7b0d7d68a8b119b6ddfd31b17d19155cd699a27e19a48bd05eb200'


### PR DESCRIPTION
Resolves a snyk issue with a hardcoded secret, not a valid security concern since it's in the test suite but it can be removed anyway, I was able to remove the whole file since `secret_token` hasn't been in use since migrating to rails 4 

https://guides.rubyonrails.org/v4.0.8/upgrading_ruby_on_rails.html#:~:text=%23%20end-,2.6%20Action%20Pack,-Rails%204.0%20introduces